### PR TITLE
fix: Syntax error on Zookeeper and Solr monitors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .terraform
 terraform.tfvars
 /.env.sh
+.idea

--- a/database/solr/monitors-solr.tf
+++ b/database/solr/monitors-solr.tf
@@ -28,7 +28,7 @@ EOQ
   require_full_window = true
   renotify_interval   = 0
 
-  tags = concat(["env:${var.environment}", "type:database", "provider:solr", "resource:solr", "team:claranet",
+  tags = concat(["env:${var.environment}", "type:database", "provider:solr", "resource:solr", "team:claranet", "created-by:terraform"], var.not_responding_extra_tags)
 
 }
 
@@ -61,7 +61,7 @@ EOQ
   require_full_window = true
   notify_no_data      = false
 
-  tags = concat(["env:${var.environment}", "type:database", "provider:solr", "resource:solr", "team:claranet",
+  tags = concat(["env:${var.environment}", "type:database", "provider:solr", "resource:solr", "team:claranet", "created-by:terraform"], var.search_handler_errors_extra_tags)
 
 }
 
@@ -93,5 +93,5 @@ EOQ
   require_full_window = true
   notify_no_data      = false
 
-  tags = concat(["env:${var.environment}", "type:database", "provider:solr", "resource:solr", "team:claranet",
+  tags = concat(["env:${var.environment}", "type:database", "provider:solr", "resource:solr", "team:claranet", "created-by:terraform"], var.searcher_warmup_time_extra_tags)
 }

--- a/database/zookeeper/monitors-zookeeper.tf
+++ b/database/zookeeper/monitors-zookeeper.tf
@@ -23,7 +23,7 @@ EOQ
   require_full_window = true
   renotify_interval   = 0
 
-  tags = concat(["env:${var.environment}", "type:database", "provider:zookeeper", "resource:zookeeper", "team:claranet",
+  tags = concat(["env:${var.environment}", "type:database", "provider:zookeeper", "resource:zookeeper", "team:claranet", "created-by:terraform"], var.zookeeper_latency_availability_extra_tags)
 
 }
 
@@ -52,6 +52,6 @@ EOQ
   locked              = false
   require_full_window = true
 
-  tags = concat(["env:${var.environment}", "type:database", "provider:zookeeper", "resource:zookeeper", "team:claranet",
+  tags = concat(["env:${var.environment}", "type:database", "provider:zookeeper", "resource:zookeeper", "team:claranet", "created-by:terraform"], var.zookeeper_latency_availability_extra_tags)
 
 }


### PR DESCRIPTION
On zookeeper and solr monitors, tags are not well-formatted