### PR TITLE
update ci image and requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     #runs-on: hashicorp/terraform:full
     runs-on: ubuntu-latest
     container:
-      image: "claranet/terraform-ci:1.0.1"
+      image: "claranet/terraform-ci:1.1.5"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -42,7 +42,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 1.0.1
+        terraform_version: 1.1.5
         terraform_wrapper: false
 
     - name: Run auto update

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     datadog = {
       source = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/caas/docker/README.md
+++ b/caas/docker/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/caas/docker/versions.tf
+++ b/caas/docker/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/caas/kubernetes/ark/README.md
+++ b/caas/kubernetes/ark/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/caas/kubernetes/ark/versions.tf
+++ b/caas/kubernetes/ark/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/caas/kubernetes/cluster/README.md
+++ b/caas/kubernetes/cluster/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/caas/kubernetes/cluster/versions.tf
+++ b/caas/kubernetes/cluster/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/caas/kubernetes/ingress/vts/README.md
+++ b/caas/kubernetes/ingress/vts/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/caas/kubernetes/ingress/vts/versions.tf
+++ b/caas/kubernetes/ingress/vts/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/caas/kubernetes/node/README.md
+++ b/caas/kubernetes/node/README.md
@@ -33,13 +33,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/caas/kubernetes/node/versions.tf
+++ b/caas/kubernetes/node/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/caas/kubernetes/pod/README.md
+++ b/caas/kubernetes/pod/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/caas/kubernetes/pod/versions.tf
+++ b/caas/kubernetes/pod/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/caas/kubernetes/velero/README.md
+++ b/caas/kubernetes/velero/README.md
@@ -28,13 +28,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/caas/kubernetes/velero/versions.tf
+++ b/caas/kubernetes/velero/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/caas/kubernetes/workload/README.md
+++ b/caas/kubernetes/workload/README.md
@@ -28,13 +28,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/caas/kubernetes/workload/versions.tf
+++ b/caas/kubernetes/workload/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/alb/README.md
+++ b/cloud/aws/alb/README.md
@@ -29,13 +29,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/alb/versions.tf
+++ b/cloud/aws/alb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/apigateway/README.md
+++ b/cloud/aws/apigateway/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/apigateway/versions.tf
+++ b/cloud/aws/apigateway/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/beanstalk/README.md
+++ b/cloud/aws/beanstalk/README.md
@@ -27,13 +27,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/beanstalk/versions.tf
+++ b/cloud/aws/beanstalk/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/ecs/common/README.md
+++ b/cloud/aws/ecs/common/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/ecs/common/versions.tf
+++ b/cloud/aws/ecs/common/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/ecs/ec2-cluster/README.md
+++ b/cloud/aws/ecs/ec2-cluster/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/ecs/ec2-cluster/versions.tf
+++ b/cloud/aws/ecs/ec2-cluster/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/ecs/fargate/README.md
+++ b/cloud/aws/ecs/fargate/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/ecs/fargate/versions.tf
+++ b/cloud/aws/ecs/fargate/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/elasticache/common/README.md
+++ b/cloud/aws/elasticache/common/README.md
@@ -29,13 +29,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/elasticache/common/versions.tf
+++ b/cloud/aws/elasticache/common/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/elasticache/memcached/README.md
+++ b/cloud/aws/elasticache/memcached/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/elasticache/memcached/versions.tf
+++ b/cloud/aws/elasticache/memcached/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/elasticache/redis/README.md
+++ b/cloud/aws/elasticache/redis/README.md
@@ -27,13 +27,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/elasticache/redis/versions.tf
+++ b/cloud/aws/elasticache/redis/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/elasticsearch/README.md
+++ b/cloud/aws/elasticsearch/README.md
@@ -28,13 +28,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/elasticsearch/versions.tf
+++ b/cloud/aws/elasticsearch/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/elb/README.md
+++ b/cloud/aws/elb/README.md
@@ -29,13 +29,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/elb/versions.tf
+++ b/cloud/aws/elb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/kinesis-firehose/README.md
+++ b/cloud/aws/kinesis-firehose/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/kinesis-firehose/versions.tf
+++ b/cloud/aws/kinesis-firehose/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/lambda/README.md
+++ b/cloud/aws/lambda/README.md
@@ -27,13 +27,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/lambda/versions.tf
+++ b/cloud/aws/lambda/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/nlb/README.md
+++ b/cloud/aws/nlb/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/nlb/versions.tf
+++ b/cloud/aws/nlb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/rds/aurora/mysql/README.md
+++ b/cloud/aws/rds/aurora/mysql/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/rds/aurora/mysql/versions.tf
+++ b/cloud/aws/rds/aurora/mysql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/rds/aurora/postgresql/README.md
+++ b/cloud/aws/rds/aurora/postgresql/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/rds/aurora/postgresql/versions.tf
+++ b/cloud/aws/rds/aurora/postgresql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/rds/common/README.md
+++ b/cloud/aws/rds/common/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/rds/common/versions.tf
+++ b/cloud/aws/rds/common/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/sqs/README.md
+++ b/cloud/aws/sqs/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/sqs/versions.tf
+++ b/cloud/aws/sqs/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/aws/vpn/README.md
+++ b/cloud/aws/vpn/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/aws/vpn/versions.tf
+++ b/cloud/aws/vpn/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/apimanagement/README.md
+++ b/cloud/azure/apimanagement/README.md
@@ -28,13 +28,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/apimanagement/versions.tf
+++ b/cloud/azure/apimanagement/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/app-gateway/README.md
+++ b/cloud/azure/app-gateway/README.md
@@ -32,13 +32,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/app-gateway/versions.tf
+++ b/cloud/azure/app-gateway/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/app-services/README.md
+++ b/cloud/azure/app-services/README.md
@@ -29,13 +29,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/app-services/versions.tf
+++ b/cloud/azure/app-services/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/azure-search/README.md
+++ b/cloud/azure/azure-search/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/azure-search/versions.tf
+++ b/cloud/azure/azure-search/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/cosmosdb/README.md
+++ b/cloud/azure/cosmosdb/README.md
@@ -27,13 +27,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/cosmosdb/versions.tf
+++ b/cloud/azure/cosmosdb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/datalakestore/README.md
+++ b/cloud/azure/datalakestore/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/datalakestore/versions.tf
+++ b/cloud/azure/datalakestore/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/eventgrid/README.md
+++ b/cloud/azure/eventgrid/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/eventgrid/versions.tf
+++ b/cloud/azure/eventgrid/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/eventhub/README.md
+++ b/cloud/azure/eventhub/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/eventhub/versions.tf
+++ b/cloud/azure/eventhub/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/functions/README.md
+++ b/cloud/azure/functions/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/functions/versions.tf
+++ b/cloud/azure/functions/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/iothubs/README.md
+++ b/cloud/azure/iothubs/README.md
@@ -37,13 +37,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/iothubs/versions.tf
+++ b/cloud/azure/iothubs/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/keyvault/README.md
+++ b/cloud/azure/keyvault/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/keyvault/versions.tf
+++ b/cloud/azure/keyvault/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/load-balancer/README.md
+++ b/cloud/azure/load-balancer/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/load-balancer/versions.tf
+++ b/cloud/azure/load-balancer/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/mysql/README.md
+++ b/cloud/azure/mysql/README.md
@@ -27,13 +27,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/mysql/versions.tf
+++ b/cloud/azure/mysql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/postgresql/README.md
+++ b/cloud/azure/postgresql/README.md
@@ -28,13 +28,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/postgresql/versions.tf
+++ b/cloud/azure/postgresql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/redis/README.md
+++ b/cloud/azure/redis/README.md
@@ -27,13 +27,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/redis/versions.tf
+++ b/cloud/azure/redis/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/serverfarms/README.md
+++ b/cloud/azure/serverfarms/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/serverfarms/versions.tf
+++ b/cloud/azure/serverfarms/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/servicebus/README.md
+++ b/cloud/azure/servicebus/README.md
@@ -27,13 +27,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/servicebus/versions.tf
+++ b/cloud/azure/servicebus/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/sql-database/README.md
+++ b/cloud/azure/sql-database/README.md
@@ -28,13 +28,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/sql-database/versions.tf
+++ b/cloud/azure/sql-database/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/sql-elasticpool/README.md
+++ b/cloud/azure/sql-elasticpool/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/sql-elasticpool/versions.tf
+++ b/cloud/azure/sql-elasticpool/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/storage/README.md
+++ b/cloud/azure/storage/README.md
@@ -56,13 +56,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/storage/versions.tf
+++ b/cloud/azure/storage/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/stream-analytics/README.md
+++ b/cloud/azure/stream-analytics/README.md
@@ -28,13 +28,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/stream-analytics/versions.tf
+++ b/cloud/azure/stream-analytics/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/azure/virtual-machine/README.md
+++ b/cloud/azure/virtual-machine/README.md
@@ -29,13 +29,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/azure/virtual-machine/versions.tf
+++ b/cloud/azure/virtual-machine/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/gcp/big-query/README.md
+++ b/cloud/gcp/big-query/README.md
@@ -32,13 +32,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/gcp/big-query/versions.tf
+++ b/cloud/gcp/big-query/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/gcp/cloud-sql/common/README.md
+++ b/cloud/gcp/cloud-sql/common/README.md
@@ -29,13 +29,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/gcp/cloud-sql/common/versions.tf
+++ b/cloud/gcp/cloud-sql/common/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/gcp/cloud-sql/mysql/README.md
+++ b/cloud/gcp/cloud-sql/mysql/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/gcp/cloud-sql/mysql/versions.tf
+++ b/cloud/gcp/cloud-sql/mysql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/gcp/gce/instance/README.md
+++ b/cloud/gcp/gce/instance/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/gcp/gce/instance/versions.tf
+++ b/cloud/gcp/gce/instance/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/gcp/lb/README.md
+++ b/cloud/gcp/lb/README.md
@@ -28,13 +28,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/gcp/lb/versions.tf
+++ b/cloud/gcp/lb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/gcp/memorystore/redis/README.md
+++ b/cloud/gcp/memorystore/redis/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/gcp/memorystore/redis/versions.tf
+++ b/cloud/gcp/memorystore/redis/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/gcp/pubsub/subscription/README.md
+++ b/cloud/gcp/pubsub/subscription/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/gcp/pubsub/subscription/versions.tf
+++ b/cloud/gcp/pubsub/subscription/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/cloud/gcp/pubsub/topic/README.md
+++ b/cloud/gcp/pubsub/topic/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/cloud/gcp/pubsub/topic/versions.tf
+++ b/cloud/gcp/pubsub/topic/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/common/module/versions.tf
+++ b/common/module/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/database/elasticsearch/README.md
+++ b/database/elasticsearch/README.md
@@ -45,13 +45,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/database/elasticsearch/versions.tf
+++ b/database/elasticsearch/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/database/mongodb/README.md
+++ b/database/mongodb/README.md
@@ -27,13 +27,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/database/mongodb/versions.tf
+++ b/database/mongodb/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/database/mysql/README.md
+++ b/database/mysql/README.md
@@ -33,13 +33,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/database/mysql/versions.tf
+++ b/database/mysql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/database/postgresql/README.md
+++ b/database/postgresql/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/database/postgresql/versions.tf
+++ b/database/postgresql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/database/proxysql/README.md
+++ b/database/proxysql/README.md
@@ -28,13 +28,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/database/proxysql/versions.tf
+++ b/database/proxysql/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/database/redis/README.md
+++ b/database/redis/README.md
@@ -33,13 +33,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/database/redis/versions.tf
+++ b/database/redis/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/database/solr/README.md
+++ b/database/solr/README.md
@@ -26,13 +26,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/database/solr/versions.tf
+++ b/database/solr/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/database/sqlserver/README.md
+++ b/database/sqlserver/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/database/sqlserver/versions.tf
+++ b/database/sqlserver/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/database/zookeeper/README.md
+++ b/database/zookeeper/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/database/zookeeper/versions.tf
+++ b/database/zookeeper/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/middleware/apache/README.md
+++ b/middleware/apache/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/middleware/apache/versions.tf
+++ b/middleware/apache/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/middleware/kong/README.md
+++ b/middleware/kong/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/middleware/kong/versions.tf
+++ b/middleware/kong/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/middleware/nginx/README.md
+++ b/middleware/nginx/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/middleware/nginx/versions.tf
+++ b/middleware/nginx/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/middleware/php-fpm/README.md
+++ b/middleware/php-fpm/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/middleware/php-fpm/versions.tf
+++ b/middleware/php-fpm/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/network/dns/README.md
+++ b/network/dns/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/network/dns/versions.tf
+++ b/network/dns/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/network/http/ssl/README.md
+++ b/network/http/ssl/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/network/http/ssl/versions.tf
+++ b/network/http/ssl/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/network/http/webcheck/README.md
+++ b/network/http/webcheck/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/network/http/webcheck/versions.tf
+++ b/network/http/webcheck/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/network/tls/README.md
+++ b/network/tls/README.md
@@ -27,13 +27,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/network/tls/versions.tf
+++ b/network/tls/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/saas/new-relic/README.md
+++ b/saas/new-relic/README.md
@@ -25,13 +25,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/saas/new-relic/versions.tf
+++ b/saas/new-relic/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/system/generic/README.md
+++ b/system/generic/README.md
@@ -31,13 +31,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/system/generic/versions.tf
+++ b/system/generic/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"

--- a/system/unreachable/README.md
+++ b/system/unreachable/README.md
@@ -24,13 +24,13 @@ Creates DataDog monitors with the following checks:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.0 |
+| <a name="requirement_datadog"></a> [datadog](#requirement\_datadog) | >= 3.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.1.2 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | >= 3.1.2 |
 
 ## Modules
 

--- a/system/unreachable/versions.tf
+++ b/system/unreachable/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 3.1.0"
+      version = ">= 3.1.2"
     }
   }
   required_version = ">= 0.12.31"


### PR DESCRIPTION
- update scripts submodule to ignore lock file with terraform-docs: https://github.com/claranet/terraform-datadog-scripts/commit/801168c2c0f9bd774e82c14c80f51be02c1c091b
- update ci image to 1.1.5 with corresponding terraform version
- update provider requirements to v3.1.2
- auto update readmes