### PR TITLE
refactor(kubernetes/workload): change group by for job monitor

### DIFF
--- a/caas/kubernetes/workload/monitors-k8s-workload.tf
+++ b/caas/kubernetes/workload/monitors-k8s-workload.tf
@@ -5,7 +5,7 @@ resource "datadog_monitor" "job" {
   type    = "service check"
 
   query = <<EOQ
-    "kubernetes_state.job.complete"${module.filter-tags.service_check}.by("job_name").last(6).count_by_status()
+    "kubernetes_state.job.complete"${module.filter-tags.service_check}.by("kube_job").last(6).count_by_status()
 EOQ
 
   monitor_thresholds {


### PR DESCRIPTION
The tag for job monitor now is `kube_job` instead of `job_name`, based in the official documentation for [Kubernetes State Metrics Core](https://docs.datadoghq.com/integrations/kubernetes_state_core/?tab=helm#migration-from-kubernetes_state-to-kubernetes_state_core)