### PR TITLE
feat(system/generic): support for monitor name prefix

### DIFF
--- a/system/generic/inputs.tf
+++ b/system/generic/inputs.tf
@@ -30,6 +30,11 @@ variable "prefix_slug" {
   default     = ""
 }
 
+variable "name_prefix" {
+  description = "Prefix string to prepend before every monitors names. Sustitute to the prefix_slug variable"
+  default     = ""
+}
+
 variable "notify_no_data" {
   description = "Will raise no data alert if set to true"
   default     = true

--- a/system/generic/monitors-system.tf
+++ b/system/generic/monitors-system.tf
@@ -1,6 +1,6 @@
 resource "datadog_monitor" "cpu" {
   count   = var.cpu_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] CPU usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} CPU usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = coalesce(var.cpu_message, var.message)
   type    = "query alert"
 
@@ -29,7 +29,7 @@ EOQ
 
 resource "datadog_monitor" "load" {
   count   = var.load_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] CPU load 5 ratio {{#is_alert}}{{{comparator}}} {{threshold}} ({{value}}){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}} ({{value}}){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} CPU load 5 ratio {{#is_alert}}{{{comparator}}} {{threshold}} ({{value}}){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}} ({{value}}){{/is_warning}}"
   message = coalesce(var.load_message, var.message)
   type    = "query alert"
 
@@ -58,7 +58,7 @@ EOQ
 
 resource "datadog_monitor" "disk_space" {
   count   = var.disk_space_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Disk space usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Disk space usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = coalesce(var.disk_space_message, var.message)
   type    = "query alert"
 
@@ -87,7 +87,7 @@ EOQ
 
 resource "datadog_monitor" "disk_space_forecast" {
   count   = var.disk_space_forecast_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Disk Space usage could reach {{#is_alert}}{{threshold}}%%{{/is_alert}} in a near future"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Disk Space usage could reach {{#is_alert}}{{threshold}}%%{{/is_alert}} in a near future"
   message = coalesce(var.disk_space_forecast_message, var.message)
   type    = "query alert"
 
@@ -123,7 +123,7 @@ EOQ
 
 resource "datadog_monitor" "disk_inodes" {
   count   = var.disk_inodes_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Disk inodes usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Disk inodes usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = coalesce(var.disk_inodes_message, var.message)
   type    = "query alert"
 
@@ -152,7 +152,7 @@ EOQ
 
 resource "datadog_monitor" "memory" {
   count   = var.memory_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Usable Memory {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${coalesce(var.name_prefix, "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}]")} Usable Memory {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
   message = var.memory_message
   type    = "query alert"
 


### PR DESCRIPTION
This PR adds a new variable for system/generic monitors to add a custom prefix to the monitors names, as a substitute to the prefix_slug variable that follow a certain format