### PR TITLE
chore: missing tag overrides for cloud aws rds monitors

### DIFF
--- a/cloud/aws/rds/common/monitors-rds-common.tf
+++ b/cloud/aws/rds/common/monitors-rds-common.tf
@@ -25,7 +25,7 @@ EOQ
   include_tags        = true
   require_full_window = false
 
-  tags = concat(["env:${var.environment}", "type:cloud", "provider:aws", "resource:rds", "team:claranet", "created-by:terraform"], var.cpu_extra_tags)
+  tags = concat(local.common_tags, var.tags, var.cpu_extra_tags)
 }
 
 ### RDS instance free space monitor ###
@@ -57,7 +57,7 @@ EOQ
   include_tags        = true
   require_full_window = false
 
-  tags = concat(["env:${var.environment}", "type:cloud", "provider:aws", "resource:rds", "team:claranet", "created-by:terraform"], var.diskspace_extra_tags)
+  tags = concat(local.common_tags, var.tags, var.diskspace_extra_tags)
 }
 
 ### RDS Replica Lag monitor ###
@@ -87,7 +87,7 @@ EOQ
   include_tags        = true
   require_full_window = false
 
-  tags = concat(["env:${var.environment}", "type:cloud", "provider:aws", "resource:rds", "team:claranet", "created-by:terraform"], var.replicalag_extra_tags)
+  tags = concat(local.common_tags, var.tags, var.replicalag_extra_tags)
 }
 
 resource "datadog_monitor" "rds_connection_variance" {
@@ -120,5 +120,5 @@ EOQ
   include_tags        = true
   require_full_window = false
 
-  tags = concat(["env:${var.environment}", "type:cloud", "provider:aws", "resource:rds", "team:claranet", "created-by:terraform"], var.connection_variance_extra_tags)
+  tags = concat(local.common_tags, var.tags, var.connection_variance_extra_tags)
 }


### PR DESCRIPTION
It seems the tag override changes were not applied to all files in this PR https://github.com/claranet/terraform-datadog-monitors/pull/51
I have not checked other files than those of cloud/aws/rds/common.
 