### PR TITLE
Changes on Kubernetes monitors

### DIFF
--- a/caas/kubernetes/cluster/README.md
+++ b/caas/kubernetes/cluster/README.md
@@ -51,7 +51,7 @@ Creates DataDog monitors with the following checks:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apiserver_enabled"></a> [apiserver\_enabled](#input\_apiserver\_enabled) | Flag to enable API server monitor | `string` | `"false"` | no |
+| <a name="input_apiserver_enabled"></a> [apiserver\_enabled](#input\_apiserver\_enabled) | Flag to enable API server monitor (do not work on some clusters, see https://docs.datadoghq.com/containers/kubernetes/control_plane/?tab=datadogoperator#ManagedServices) | `string` | `"false"` | no |
 | <a name="input_apiserver_extra_tags"></a> [apiserver\_extra\_tags](#input\_apiserver\_extra\_tags) | Extra tags for API server monitor | `list(string)` | `[]` | no |
 | <a name="input_apiserver_message"></a> [apiserver\_message](#input\_apiserver\_message) | Custom message for API server monitor | `string` | `""` | no |
 | <a name="input_apiserver_no_data_timeframe"></a> [apiserver\_no\_data\_timeframe](#input\_apiserver\_no\_data\_timeframe) | Number of minutes before reporting no data | `string` | `10` | no |

--- a/caas/kubernetes/cluster/README.md
+++ b/caas/kubernetes/cluster/README.md
@@ -18,6 +18,7 @@ module "datadog-monitors-caas-kubernetes-cluster" {
 Creates DataDog monitors with the following checks:
 
 - Kubernetes API server does not respond
+- Kubernetes cluster heartbeat alert on {{kube_cluster_name}}
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -44,6 +45,7 @@ Creates DataDog monitors with the following checks:
 | Name | Type |
 |------|------|
 | [datadog_monitor.apiserver](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
+| [datadog_monitor.heartbeat](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 
 ## Inputs
 
@@ -60,6 +62,12 @@ Creates DataDog monitors with the following checks:
 | <a name="input_filter_tags_custom_excluded"></a> [filter\_tags\_custom\_excluded](#input\_filter\_tags\_custom\_excluded) | Tags excluded for custom filtering when filter\_tags\_use\_defaults is false | `string` | `""` | no |
 | <a name="input_filter_tags_separator"></a> [filter\_tags\_separator](#input\_filter\_tags\_separator) | Set the filter tags separator (, or AND) | `string` | `","` | no |
 | <a name="input_filter_tags_use_defaults"></a> [filter\_tags\_use\_defaults](#input\_filter\_tags\_use\_defaults) | Use default filter tags convention | `string` | `"true"` | no |
+| <a name="input_heartbeat_enabled"></a> [heartbeat\_enabled](#input\_heartbeat\_enabled) | Flag to enable heartbeat monitor | `string` | `"true"` | no |
+| <a name="input_heartbeat_extra_tags"></a> [heartbeat\_extra\_tags](#input\_heartbeat\_extra\_tags) | Extra tags for heartbeat monitor | `list(string)` | `[]` | no |
+| <a name="input_heartbeat_message"></a> [heartbeat\_message](#input\_heartbeat\_message) | Custom message for heartbeat monitor | `string` | `""` | no |
+| <a name="input_heartbeat_no_data_timeframe"></a> [heartbeat\_no\_data\_timeframe](#input\_heartbeat\_no\_data\_timeframe) | Number of minutes before reporting no data | `string` | `20` | no |
+| <a name="input_heartbeat_time_aggregator"></a> [heartbeat\_time\_aggregator](#input\_heartbeat\_time\_aggregator) | Time aggregator for heartbeat monitor | `string` | `"min"` | no |
+| <a name="input_heartbeat_timeframe"></a> [heartbeat\_timeframe](#input\_heartbeat\_timeframe) | Timeframe for heartbeat monitor | `string` | `"last_30m"` | no |
 | <a name="input_message"></a> [message](#input\_message) | Message sent when a monitor is triggered | `any` | n/a | yes |
 | <a name="input_new_group_delay"></a> [new\_group\_delay](#input\_new\_group\_delay) | Delay in seconds before monitor new resource | `number` | `300` | no |
 | <a name="input_new_host_delay"></a> [new\_host\_delay](#input\_new\_host\_delay) | Delay in seconds before monitor new resource | `number` | `300` | no |
@@ -74,6 +82,7 @@ Creates DataDog monitors with the following checks:
 | Name | Description |
 |------|-------------|
 | <a name="output_apiserver_id"></a> [apiserver\_id](#output\_apiserver\_id) | id for monitor apiserver |
+| <a name="output_heartbeat_id"></a> [heartbeat\_id](#output\_heartbeat\_id) | id for monitor heartbeat |
 <!-- END_TF_DOCS -->
 ## Related documentation
 

--- a/caas/kubernetes/cluster/README.md
+++ b/caas/kubernetes/cluster/README.md
@@ -17,7 +17,7 @@ module "datadog-monitors-caas-kubernetes-cluster" {
 
 Creates DataDog monitors with the following checks:
 
-- Kubernetes API server does not respond
+- Kubernetes API server does not respond on {{kube_cluster_name}} (disabled by default)
 - Kubernetes cluster heartbeat alert on {{kube_cluster_name}}
 
 <!-- BEGIN_TF_DOCS -->
@@ -51,7 +51,7 @@ Creates DataDog monitors with the following checks:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apiserver_enabled"></a> [apiserver\_enabled](#input\_apiserver\_enabled) | Flag to enable API server monitor | `string` | `"true"` | no |
+| <a name="input_apiserver_enabled"></a> [apiserver\_enabled](#input\_apiserver\_enabled) | Flag to enable API server monitor | `string` | `"false"` | no |
 | <a name="input_apiserver_extra_tags"></a> [apiserver\_extra\_tags](#input\_apiserver\_extra\_tags) | Extra tags for API server monitor | `list(string)` | `[]` | no |
 | <a name="input_apiserver_message"></a> [apiserver\_message](#input\_apiserver\_message) | Custom message for API server monitor | `string` | `""` | no |
 | <a name="input_apiserver_no_data_timeframe"></a> [apiserver\_no\_data\_timeframe](#input\_apiserver\_no\_data\_timeframe) | Number of minutes before reporting no data | `string` | `10` | no |

--- a/caas/kubernetes/cluster/inputs.tf
+++ b/caas/kubernetes/cluster/inputs.tf
@@ -68,7 +68,7 @@ variable "apiserver_no_data_timeframe" {
 # Datadog monitors variables
 ## API server monitor variables
 variable "apiserver_enabled" {
-  description = "Flag to enable API server monitor"
+  description = "Flag to enable API server monitor (do not work on some clusters, see https://docs.datadoghq.com/containers/kubernetes/control_plane/?tab=datadogoperator#ManagedServices)"
   type        = string
   default     = "false"
 }

--- a/caas/kubernetes/cluster/inputs.tf
+++ b/caas/kubernetes/cluster/inputs.tf
@@ -70,7 +70,7 @@ variable "apiserver_no_data_timeframe" {
 variable "apiserver_enabled" {
   description = "Flag to enable API server monitor"
   type        = string
-  default     = "true"
+  default     = "false"
 }
 
 variable "apiserver_extra_tags" {

--- a/caas/kubernetes/cluster/inputs.tf
+++ b/caas/kubernetes/cluster/inputs.tf
@@ -66,7 +66,7 @@ variable "apiserver_no_data_timeframe" {
 }
 
 # Datadog monitors variables
-
+## API server monitor variables
 variable "apiserver_enabled" {
   description = "Flag to enable API server monitor"
   type        = string
@@ -91,3 +91,39 @@ variable "apiserver_threshold_warning" {
   default     = 3
 }
 
+## Heartbeat monitor variables
+variable "heartbeat_enabled" {
+  description = "Flag to enable heartbeat monitor"
+  type        = string
+  default     = "true"
+}
+
+variable "heartbeat_message" {
+  description = "Custom message for heartbeat monitor"
+  type        = string
+  default     = ""
+}
+
+variable "heartbeat_no_data_timeframe" {
+  description = "Number of minutes before reporting no data"
+  type        = string
+  default     = 20
+}
+
+variable "heartbeat_time_aggregator" {
+  description = "Time aggregator for heartbeat monitor"
+  type        = string
+  default     = "min"
+}
+
+variable "heartbeat_timeframe" {
+  description = "Timeframe for heartbeat monitor"
+  type        = string
+  default     = "last_30m"
+}
+
+variable "heartbeat_extra_tags" {
+  description = "Extra tags for heartbeat monitor"
+  type        = list(string)
+  default     = []
+}

--- a/caas/kubernetes/cluster/monitors-k8s-cluster.tf
+++ b/caas/kubernetes/cluster/monitors-k8s-cluster.tf
@@ -26,3 +26,30 @@ EOQ
 
   tags = concat(local.common_tags, var.tags, var.apiserver_extra_tags)
 }
+
+resource "datadog_monitor" "heartbeat" {
+  count   = var.heartbeat_enabled == "true" ? 1 : 0
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes cluster heartbeat alert on {{kube_cluster_name}}"
+  message = coalesce(var.heartbeat_message, var.message)
+  type    = "metric alert"
+
+  query = <<EOQ
+    ${var.heartbeat_time_aggregator}(${var.heartbeat_timeframe}):
+    sum:kubernetes.pods.running${module.filter-tags.query_alert} by {kube_cluster_name} > 1000000
+EOQ
+
+  monitor_thresholds {
+    critical = 1000000 # high threshold to handle no data only
+  }
+
+  new_group_delay     = var.new_group_delay
+  notify_no_data      = true
+  no_data_timeframe   = var.heartbeat_no_data_timeframe
+  renotify_interval   = 0
+  notify_audit        = false
+  timeout_h           = var.timeout_h
+  include_tags        = true
+  require_full_window = true
+
+  tags = concat(local.common_tags, var.tags, var.heartbeat_extra_tags)
+}

--- a/caas/kubernetes/cluster/monitors-k8s-cluster.tf
+++ b/caas/kubernetes/cluster/monitors-k8s-cluster.tf
@@ -1,12 +1,12 @@
 resource "datadog_monitor" "apiserver" {
   count   = var.apiserver_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes API server does not respond"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes API server does not respond on {{kube_cluster_name}}"
   message = coalesce(var.apiserver_message, var.message)
 
   type = "service check"
 
   query = <<EOQ
-    "kube_apiserver_controlplane.up"${module.filter-tags.service_check}.last(6).count_by_status()
+    "kube_apiserver_controlplane.up"${module.filter-tags.service_check}.by("kube_cluster_name").last(6).count_by_status()
 EOQ
 
   monitor_thresholds {
@@ -16,7 +16,7 @@ EOQ
 
   new_host_delay      = var.new_host_delay
   new_group_delay     = var.new_group_delay
-  notify_no_data      = var.notify_no_data
+  notify_no_data      = false
   no_data_timeframe   = var.apiserver_no_data_timeframe
   renotify_interval   = 0
   notify_audit        = false

--- a/caas/kubernetes/cluster/outputs.tf
+++ b/caas/kubernetes/cluster/outputs.tf
@@ -3,3 +3,8 @@ output "apiserver_id" {
   value       = datadog_monitor.apiserver.*.id
 }
 
+output "heartbeat_id" {
+  description = "id for monitor heartbeat"
+  value       = datadog_monitor.heartbeat.*.id
+}
+

--- a/caas/kubernetes/ingress/vts/README.md
+++ b/caas/kubernetes/ingress/vts/README.md
@@ -19,6 +19,7 @@ Creates DataDog monitors with the following checks:
 
 - Nginx Ingress 4xx errors
 - Nginx Ingress 5xx errors
+- Nginx Ingress {{kube_replica_set}} is down on {{kube_cluster_name}}
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -46,6 +47,7 @@ Creates DataDog monitors with the following checks:
 
 | Name | Type |
 |------|------|
+| [datadog_monitor.nginx_ingress_is_down](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.nginx_ingress_too_many_4xx](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.nginx_ingress_too_many_5xx](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 
@@ -74,6 +76,13 @@ Creates DataDog monitors with the following checks:
 | <a name="input_ingress_5xx_threshold_warning"></a> [ingress\_5xx\_threshold\_warning](#input\_ingress\_5xx\_threshold\_warning) | 5xx warning threshold in percentage | `string` | `"10"` | no |
 | <a name="input_ingress_5xx_time_aggregator"></a> [ingress\_5xx\_time\_aggregator](#input\_ingress\_5xx\_time\_aggregator) | Monitor aggregator for Ingress 5xx errors [available values: min, max or avg] | `string` | `"min"` | no |
 | <a name="input_ingress_5xx_timeframe"></a> [ingress\_5xx\_timeframe](#input\_ingress\_5xx\_timeframe) | Monitor timeframe for Ingress 5xx errors [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_5m"` | no |
+| <a name="input_ingress_down_enabled"></a> [ingress\_down\_enabled](#input\_ingress\_down\_enabled) | Flag to enable Nginx Ingress is down monitor | `string` | `"true"` | no |
+| <a name="input_ingress_down_extra_tags"></a> [ingress\_down\_extra\_tags](#input\_ingress\_down\_extra\_tags) | Extra tags for Nginx Ingress is down monitor | `list(string)` | `[]` | no |
+| <a name="input_ingress_down_message"></a> [ingress\_down\_message](#input\_ingress\_down\_message) | Message sent when an alert is triggered | `string` | `""` | no |
+| <a name="input_ingress_down_threshold_critical"></a> [ingress\_down\_threshold\_critical](#input\_ingress\_down\_threshold\_critical) | Nginx Ingress is down critical threshold in percentage | `number` | `0.3` | no |
+| <a name="input_ingress_down_threshold_warning"></a> [ingress\_down\_threshold\_warning](#input\_ingress\_down\_threshold\_warning) | Nginx Ingress is down warning threshold in percentage | `number` | `0.7` | no |
+| <a name="input_ingress_down_time_aggregator"></a> [ingress\_down\_time\_aggregator](#input\_ingress\_down\_time\_aggregator) | Monitor aggregator for Nginx Ingress is down [available values: min, max or avg] | `string` | `"avg"` | no |
+| <a name="input_ingress_down_timeframe"></a> [ingress\_down\_timeframe](#input\_ingress\_down\_timeframe) | Monitor timeframe for Nginx Ingress is down [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_10m"` | no |
 | <a name="input_message"></a> [message](#input\_message) | Message sent when an alert is triggered | `any` | n/a | yes |
 | <a name="input_new_group_delay"></a> [new\_group\_delay](#input\_new\_group\_delay) | Delay in seconds before monitor new resource | `number` | `300` | no |
 | <a name="input_new_host_delay"></a> [new\_host\_delay](#input\_new\_host\_delay) | Delay in seconds before monitor new resource | `number` | `300` | no |
@@ -87,6 +96,7 @@ Creates DataDog monitors with the following checks:
 
 | Name | Description |
 |------|-------------|
+| <a name="output_nginx_ingress_is_down_id"></a> [nginx\_ingress\_is\_down\_id](#output\_nginx\_ingress\_is\_down\_id) | id for monitor nginx\_ingress\_is\_down |
 | <a name="output_nginx_ingress_too_many_4xx_id"></a> [nginx\_ingress\_too\_many\_4xx\_id](#output\_nginx\_ingress\_too\_many\_4xx\_id) | id for monitor nginx\_ingress\_too\_many\_4xx |
 | <a name="output_nginx_ingress_too_many_5xx_id"></a> [nginx\_ingress\_too\_many\_5xx\_id](#output\_nginx\_ingress\_too\_many\_5xx\_id) | id for monitor nginx\_ingress\_too\_many\_5xx |
 <!-- END_TF_DOCS -->

--- a/caas/kubernetes/ingress/vts/inputs.tf
+++ b/caas/kubernetes/ingress/vts/inputs.tf
@@ -59,8 +59,8 @@ variable "filter_tags_separator" {
   default     = ","
 }
 
-#Ingress
-
+# Nginx Ingress
+## Nginx Ingress 5xx errors monitor
 variable "ingress_5xx_enabled" {
   description = "Flag to enable Ingress 5xx errors monitor"
   type        = string
@@ -102,6 +102,7 @@ variable "ingress_5xx_threshold_warning" {
   description = "5xx warning threshold in percentage"
 }
 
+## Nginx Ingress 4xx errors monitor
 variable "ingress_4xx_enabled" {
   description = "Flag to enable Ingress 4xx errors monitor"
   type        = string
@@ -148,3 +149,44 @@ variable "artificial_requests_count" {
   description = "Number of false requests used to mitigate false positive in case of low trafic"
 }
 
+## Nginx Ingress is down monitor
+variable "ingress_down_enabled" {
+  type        = string
+  default     = "true"
+  description = "Flag to enable Nginx Ingress is down monitor"
+}
+
+variable "ingress_down_message" {
+  default     = ""
+  description = "Message sent when an alert is triggered"
+}
+
+variable "ingress_down_time_aggregator" {
+  type        = string
+  default     = "avg"
+  description = "Monitor aggregator for Nginx Ingress is down [available values: min, max or avg]"
+}
+
+variable "ingress_down_timeframe" {
+  type        = string
+  default     = "last_10m"
+  description = "Monitor timeframe for Nginx Ingress is down [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`]"
+}
+
+variable "ingress_down_threshold_critical" {
+  type        = number
+  default     = 0.3
+  description = "Nginx Ingress is down critical threshold in percentage"
+}
+
+variable "ingress_down_threshold_warning" {
+  type        = number
+  default     = 0.7
+  description = "Nginx Ingress is down warning threshold in percentage"
+}
+
+variable "ingress_down_extra_tags" {
+  type        = list(string)
+  default     = []
+  description = "Extra tags for Nginx Ingress is down monitor"
+}

--- a/caas/kubernetes/ingress/vts/outputs.tf
+++ b/caas/kubernetes/ingress/vts/outputs.tf
@@ -1,3 +1,8 @@
+output "nginx_ingress_is_down_id" {
+  description = "id for monitor nginx_ingress_is_down"
+  value       = datadog_monitor.nginx_ingress_is_down.*.id
+}
+
 output "nginx_ingress_too_many_4xx_id" {
   description = "id for monitor nginx_ingress_too_many_4xx"
   value       = datadog_monitor.nginx_ingress_too_many_4xx.*.id

--- a/caas/kubernetes/node/README.md
+++ b/caas/kubernetes/node/README.md
@@ -17,15 +17,15 @@ module "datadog-monitors-caas-kubernetes-node" {
 
 Creates DataDog monitors with the following checks:
 
-- Kubernetes Node Disk pressure
-- Kubernetes Node Frequent unregister net device
-- Kubernetes Node Kubelet API does not respond
-- Kubernetes Node Kubelet sync loop that updates containers does not work
-- Kubernetes Node Memory pressure
-- Kubernetes Node not ready
-- Kubernetes Node unschedulable
-- Kubernetes Node volume inodes usage
-- Kubernetes Node volume space usage
+- Kubernetes Node {{kube_node}} disk pressure on {{kube_cluster_name}}
+- Kubernetes Node {{kube_node}} frequent unregister net device
+- Kubernetes Node {{kube_node}} Kubelet API does not respond on {{kube_cluster_name}}
+- Kubernetes Node {{kube_node}} Kubelet sync loop that updates containers does not work on {{kube_cluster_name}}
+- Kubernetes Node {{kube_node}} memory pressure on {{kube_cluster_name}}
+- Kubernetes Node {{kube_node}} not ready on {{kube_cluster_name}}
+- Kubernetes Node {{kube_node}} unschedulable on {{kube_cluster_name}}
+- Kubernetes Node volume {{persistentvolumeclaim}} inodes usage
+- Kubernetes Node volume {{persistentvolumeclaim}} space usage
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/caas/kubernetes/node/README.md
+++ b/caas/kubernetes/node/README.md
@@ -23,7 +23,6 @@ Creates DataDog monitors with the following checks:
 - Kubernetes Node Kubelet sync loop that updates containers does not work
 - Kubernetes Node Memory pressure
 - Kubernetes Node not ready
-- Kubernetes Node Out of disk
 - Kubernetes Node unschedulable
 - Kubernetes Node volume inodes usage
 - Kubernetes Node volume space usage
@@ -53,7 +52,6 @@ Creates DataDog monitors with the following checks:
 
 | Name | Type |
 |------|------|
-| [datadog_monitor.disk_out](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.disk_pressure](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.kubelet_ping](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.kubelet_syncloop](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
@@ -68,10 +66,6 @@ Creates DataDog monitors with the following checks:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_disk_out_enabled"></a> [disk\_out\_enabled](#input\_disk\_out\_enabled) | Flag to enable Out of disk monitor | `string` | `"true"` | no |
-| <a name="input_disk_out_extra_tags"></a> [disk\_out\_extra\_tags](#input\_disk\_out\_extra\_tags) | Extra tags for Out of disk monitor | `list(string)` | `[]` | no |
-| <a name="input_disk_out_message"></a> [disk\_out\_message](#input\_disk\_out\_message) | Custom message for Out of disk monitor | `string` | `""` | no |
-| <a name="input_disk_out_threshold_warning"></a> [disk\_out\_threshold\_warning](#input\_disk\_out\_threshold\_warning) | Out of disk monitor (warning threshold) | `string` | `3` | no |
 | <a name="input_disk_pressure_enabled"></a> [disk\_pressure\_enabled](#input\_disk\_pressure\_enabled) | Flag to enable Disk pressure monitor | `string` | `"true"` | no |
 | <a name="input_disk_pressure_extra_tags"></a> [disk\_pressure\_extra\_tags](#input\_disk\_pressure\_extra\_tags) | Extra tags for Disk pressure monitor | `list(string)` | `[]` | no |
 | <a name="input_disk_pressure_message"></a> [disk\_pressure\_message](#input\_disk\_pressure\_message) | Custom message for Disk pressure monitor | `string` | `""` | no |
@@ -137,7 +131,6 @@ Creates DataDog monitors with the following checks:
 
 | Name | Description |
 |------|-------------|
-| <a name="output_disk_out_id"></a> [disk\_out\_id](#output\_disk\_out\_id) | id for monitor disk\_out |
 | <a name="output_disk_pressure_id"></a> [disk\_pressure\_id](#output\_disk\_pressure\_id) | id for monitor disk\_pressure |
 | <a name="output_kubelet_ping_id"></a> [kubelet\_ping\_id](#output\_kubelet\_ping\_id) | id for monitor kubelet\_ping |
 | <a name="output_kubelet_syncloop_id"></a> [kubelet\_syncloop\_id](#output\_kubelet\_syncloop\_id) | id for monitor kubelet\_syncloop |

--- a/caas/kubernetes/node/inputs.tf
+++ b/caas/kubernetes/node/inputs.tf
@@ -91,30 +91,6 @@ variable "disk_pressure_threshold_warning" {
   default     = 3
 }
 
-variable "disk_out_enabled" {
-  description = "Flag to enable Out of disk monitor"
-  type        = string
-  default     = "true"
-}
-
-variable "disk_out_extra_tags" {
-  description = "Extra tags for Out of disk monitor"
-  type        = list(string)
-  default     = []
-}
-
-variable "disk_out_message" {
-  description = "Custom message for Out of disk monitor"
-  type        = string
-  default     = ""
-}
-
-variable "disk_out_threshold_warning" {
-  description = "Out of disk monitor (warning threshold)"
-  type        = string
-  default     = 3
-}
-
 variable "memory_pressure_enabled" {
   description = "Flag to enable Memory pressure monitor"
   type        = string

--- a/caas/kubernetes/node/monitors-k8s-node.tf
+++ b/caas/kubernetes/node/monitors-k8s-node.tf
@@ -1,6 +1,6 @@
 resource "datadog_monitor" "disk_pressure" {
   count   = var.disk_pressure_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Disk pressure"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node {{kube_node}} disk pressure on {{kube_cluster_name}}"
   message = coalesce(var.disk_pressure_message, var.message)
   type    = "service check"
 
@@ -27,7 +27,7 @@ EOQ
 
 resource "datadog_monitor" "memory_pressure" {
   count   = var.memory_pressure_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Memory pressure"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node {{kube_node}} memory pressure on {{kube_cluster_name}}"
   message = coalesce(var.memory_pressure_message, var.message)
   type    = "service check"
 
@@ -54,7 +54,7 @@ EOQ
 
 resource "datadog_monitor" "ready" {
   count   = var.ready_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node not ready"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node {{kube_node}} not ready on {{kube_cluster_name}}"
   message = coalesce(var.ready_message, var.message)
   type    = "service check"
 
@@ -81,12 +81,12 @@ EOQ
 
 resource "datadog_monitor" "kubelet_ping" {
   count   = var.kubelet_ping_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Kubelet API does not respond"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node {{kube_node}} Kubelet API does not respond on {{kube_cluster_name}}"
   message = coalesce(var.kubelet_ping_message, var.message)
   type    = "service check"
 
   query = <<EOQ
-    "kubernetes.kubelet.check.ping"${module.filter-tags.service_check}.by("name","kube_cluster_name").last(6).count_by_status()
+    "kubernetes.kubelet.check.ping"${module.filter-tags.service_check}.by("kube_node","kube_cluster_name").last(6).count_by_status()
 EOQ
 
   monitor_thresholds {
@@ -109,12 +109,12 @@ EOQ
 
 resource "datadog_monitor" "kubelet_syncloop" {
   count   = var.kubelet_syncloop_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Kubelet sync loop that updates containers does not work"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node {{kube_node}} Kubelet sync loop that updates containers does not work on {{kube_cluster_name}}"
   message = coalesce(var.kubelet_syncloop_message, var.message)
   type    = "service check"
 
   query = <<EOQ
-    "kubernetes.kubelet.check.syncloop"${module.filter-tags.service_check}.by("name","kube_cluster_name").last(6).count_by_status()
+    "kubernetes.kubelet.check.syncloop"${module.filter-tags.service_check}.by("kube_node","kube_cluster_name").last(6).count_by_status()
 EOQ
 
   monitor_thresholds {
@@ -136,7 +136,7 @@ EOQ
 
 resource "datadog_monitor" "unregister_net_device" {
   count   = var.unregister_net_device_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Frequent unregister net device"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node {{kube_node}} frequent unregister net device"
   message = coalesce(var.unregister_net_device_message, var.message)
   type    = "event-v2 alert"
 
@@ -154,7 +154,7 @@ resource "datadog_monitor" "unregister_net_device" {
 
 resource "datadog_monitor" "node_unschedulable" {
   count   = var.node_unschedulable_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node unschedulable"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node {{kube_node}} unschedulable on {{kube_cluster_name}}"
   message = coalesce(var.node_unschedulable_message, var.message)
   type    = "metric alert"
 
@@ -183,7 +183,7 @@ EOQ
 
 resource "datadog_monitor" "volume_space" {
   count   = var.volume_space_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node volume space usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node volume {{persistentvolumeclaim}} space usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}} on {{kube_cluster_name}}"
   message = coalesce(var.volume_space_message, var.message)
   type    = "query alert"
 
@@ -214,7 +214,7 @@ EOQ
 
 resource "datadog_monitor" "volume_inodes" {
   count   = var.volume_inodes_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node volume inodes usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}}"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node volume {{persistentvolumeclaim}} inodes usage {{#is_alert}}{{{comparator}}} {{threshold}}% ({{value}}%){{/is_alert}}{{#is_warning}}{{{comparator}}} {{warn_threshold}}% ({{value}}%){{/is_warning}} on {{kube_cluster_name}}"
   message = coalesce(var.volume_inodes_message, var.message)
   type    = "query alert"
 

--- a/caas/kubernetes/node/monitors-k8s-node.tf
+++ b/caas/kubernetes/node/monitors-k8s-node.tf
@@ -25,33 +25,6 @@ EOQ
   tags = concat(local.common_tags, var.tags, var.disk_pressure_extra_tags)
 }
 
-resource "datadog_monitor" "disk_out" {
-  count   = var.disk_out_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Out of disk"
-  message = coalesce(var.disk_out_message, var.message)
-  type    = "service check"
-
-  query = <<EOQ
-    "kubernetes_state.node.out_of_disk"${module.filter-tags.service_check}.by("kube_node","kube_cluster_name").last(6).count_by_status()
-EOQ
-
-  monitor_thresholds {
-    warning  = var.disk_out_threshold_warning
-    critical = 5
-  }
-
-  new_host_delay      = var.new_host_delay
-  new_group_delay     = var.new_group_delay
-  notify_no_data      = false
-  renotify_interval   = 0
-  notify_audit        = false
-  timeout_h           = var.timeout_h
-  include_tags        = true
-  require_full_window = true
-
-  tags = concat(local.common_tags, var.tags, var.disk_out_extra_tags)
-}
-
 resource "datadog_monitor" "memory_pressure" {
   count   = var.memory_pressure_enabled == "true" ? 1 : 0
   name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Node Memory pressure"

--- a/caas/kubernetes/node/outputs.tf
+++ b/caas/kubernetes/node/outputs.tf
@@ -1,8 +1,3 @@
-output "disk_out_id" {
-  description = "id for monitor disk_out"
-  value       = datadog_monitor.disk_out.*.id
-}
-
 output "disk_pressure_id" {
   description = "id for monitor disk_pressure"
   value       = datadog_monitor.disk_pressure.*.id

--- a/caas/kubernetes/pod/README.md
+++ b/caas/kubernetes/pod/README.md
@@ -21,7 +21,7 @@ Creates DataDog monitors with the following checks:
 - Kubernetes Pod {{pod_name}} container {{kube_container_name}} killed by OOM on {{kube_cluster_name}}
 - Kubernetes Pod terminated abnormally
 - Kubernetes Pod waiting errors
-- Kubernetes pods in {{kube_replica_set}} frequently restarted on {{kube_cluster_name}}
+- Kubernetes Pods in {{kube_replica_set}} frequently restarted on {{kube_cluster_name}}
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/caas/kubernetes/pod/README.md
+++ b/caas/kubernetes/pod/README.md
@@ -18,8 +18,10 @@ module "datadog-monitors-caas-kubernetes-pod" {
 Creates DataDog monitors with the following checks:
 
 - Kubernetes Pod phase status failed
+- Kubernetes Pod {{pod_name}} container {{kube_container_name}} killed by OOM on {{kube_cluster_name}}
 - Kubernetes Pod terminated abnormally
 - Kubernetes Pod waiting errors
+- Kubernetes pods in {{kube_replica_set}} frequently restarted on {{kube_cluster_name}}
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -48,6 +50,8 @@ Creates DataDog monitors with the following checks:
 | Name | Type |
 |------|------|
 | [datadog_monitor.error](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
+| [datadog_monitor.pod_container_killed_by_oom](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
+| [datadog_monitor.pod_frequently_restarted](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.pod_phase_status](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.terminated](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 
@@ -72,6 +76,20 @@ Creates DataDog monitors with the following checks:
 | <a name="input_new_group_delay"></a> [new\_group\_delay](#input\_new\_group\_delay) | Delay in seconds before monitor new resource | `number` | `300` | no |
 | <a name="input_new_host_delay"></a> [new\_host\_delay](#input\_new\_host\_delay) | Delay in seconds before monitor new resource | `number` | `300` | no |
 | <a name="input_notify_no_data"></a> [notify\_no\_data](#input\_notify\_no\_data) | Will raise no data alert if set to true | `bool` | `true` | no |
+| <a name="input_pod_container_killed_by_oom_enabled"></a> [pod\_container\_killed\_by\_oom\_enabled](#input\_pod\_container\_killed\_by\_oom\_enabled) | Flag to enable Pod container killed by OOM monitor | `string` | `"true"` | no |
+| <a name="input_pod_container_killed_by_oom_extra_tags"></a> [pod\_container\_killed\_by\_oom\_extra\_tags](#input\_pod\_container\_killed\_by\_oom\_extra\_tags) | Extra tags for Pod container killed by OOM monitor | `list(string)` | `[]` | no |
+| <a name="input_pod_container_killed_by_oom_message"></a> [pod\_container\_killed\_by\_oom\_message](#input\_pod\_container\_killed\_by\_oom\_message) | Custom message for Pod container killed by OOM monitor | `string` | `""` | no |
+| <a name="input_pod_container_killed_by_oom_threshold_critical"></a> [pod\_container\_killed\_by\_oom\_threshold\_critical](#input\_pod\_container\_killed\_by\_oom\_threshold\_critical) | Pod container killed by OOM critical threshold | `number` | `5` | no |
+| <a name="input_pod_container_killed_by_oom_threshold_warning"></a> [pod\_container\_killed\_by\_oom\_threshold\_warning](#input\_pod\_container\_killed\_by\_oom\_threshold\_warning) | Pod container killed by OOM warning threshold | `number` | `0` | no |
+| <a name="input_pod_container_killed_by_oom_time_aggregator"></a> [pod\_container\_killed\_by\_oom\_time\_aggregator](#input\_pod\_container\_killed\_by\_oom\_time\_aggregator) | Monitor aggregator for Pod container killed by OOM [available values: min, max or avg] | `string` | `"avg"` | no |
+| <a name="input_pod_container_killed_by_oom_timeframe"></a> [pod\_container\_killed\_by\_oom\_timeframe](#input\_pod\_container\_killed\_by\_oom\_timeframe) | Monitor timeframe for Pod container killed by OOM [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_15m"` | no |
+| <a name="input_pod_frequently_restarted_enabled"></a> [pod\_frequently\_restarted\_enabled](#input\_pod\_frequently\_restarted\_enabled) | Flag to enable Pod frequently restarted monitor | `string` | `"true"` | no |
+| <a name="input_pod_frequently_restarted_extra_tags"></a> [pod\_frequently\_restarted\_extra\_tags](#input\_pod\_frequently\_restarted\_extra\_tags) | Extra tags for Pod frequently restarted monitor | `list(string)` | `[]` | no |
+| <a name="input_pod_frequently_restarted_message"></a> [pod\_frequently\_restarted\_message](#input\_pod\_frequently\_restarted\_message) | Custom message for Pod frequently restarted monitor | `string` | `""` | no |
+| <a name="input_pod_frequently_restarted_threshold_critical"></a> [pod\_frequently\_restarted\_threshold\_critical](#input\_pod\_frequently\_restarted\_threshold\_critical) | Pod frequently restarted critical threshold | `number` | `10` | no |
+| <a name="input_pod_frequently_restarted_threshold_warning"></a> [pod\_frequently\_restarted\_threshold\_warning](#input\_pod\_frequently\_restarted\_threshold\_warning) | Pod frequently restarted warning threshold | `number` | `5` | no |
+| <a name="input_pod_frequently_restarted_time_aggregator"></a> [pod\_frequently\_restarted\_time\_aggregator](#input\_pod\_frequently\_restarted\_time\_aggregator) | Monitor aggregator for Pod frequently restarted [available values: min, max or avg] | `string` | `"min"` | no |
+| <a name="input_pod_frequently_restarted_timeframe"></a> [pod\_frequently\_restarted\_timeframe](#input\_pod\_frequently\_restarted\_timeframe) | Monitor timeframe for Pod frequently restarted [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_15m"` | no |
 | <a name="input_pod_group_by"></a> [pod\_group\_by](#input\_pod\_group\_by) | Select group by element on monitors (error and terminated) | `list` | <pre>[<br>  "kube_namespace",<br>  "pod_name",<br>  "reason",<br>  "kube_cluster_name"<br>]</pre> | no |
 | <a name="input_pod_phase_status_enabled"></a> [pod\_phase\_status\_enabled](#input\_pod\_phase\_status\_enabled) | Flag to enable Pod phase status monitor | `string` | `"true"` | no |
 | <a name="input_pod_phase_status_extra_tags"></a> [pod\_phase\_status\_extra\_tags](#input\_pod\_phase\_status\_extra\_tags) | Extra tags for Pod phase status monitor | `list(string)` | `[]` | no |
@@ -96,6 +114,8 @@ Creates DataDog monitors with the following checks:
 | Name | Description |
 |------|-------------|
 | <a name="output_error_id"></a> [error\_id](#output\_error\_id) | id for monitor error |
+| <a name="output_pod_container_killed_by_oom_id"></a> [pod\_container\_killed\_by\_oom\_id](#output\_pod\_container\_killed\_by\_oom\_id) | id for monitor pod\_container\_killed\_by\_oom |
+| <a name="output_pod_frequently_restarted_id"></a> [pod\_frequently\_restarted\_id](#output\_pod\_frequently\_restarted\_id) | id for monitor pod\_frequently\_restarted |
 | <a name="output_pod_phase_status_id"></a> [pod\_phase\_status\_id](#output\_pod\_phase\_status\_id) | id for monitor pod\_phase\_status |
 | <a name="output_terminated_id"></a> [terminated\_id](#output\_terminated\_id) | id for monitor terminated |
 <!-- END_TF_DOCS -->

--- a/caas/kubernetes/pod/inputs.tf
+++ b/caas/kubernetes/pod/inputs.tf
@@ -171,6 +171,93 @@ variable "terminated_threshold_warning" {
   description = "terminated warning threshold"
 }
 
+# Pod container killed by OOM
+variable "pod_container_killed_by_oom_enabled" {
+  description = "Flag to enable Pod container killed by OOM monitor"
+  type        = string
+  default     = "true"
+}
+
+variable "pod_container_killed_by_oom_message" {
+  description = "Custom message for Pod container killed by OOM monitor"
+  type        = string
+  default     = ""
+}
+
+variable "pod_container_killed_by_oom_time_aggregator" {
+  description = "Monitor aggregator for Pod container killed by OOM [available values: min, max or avg]"
+  type        = string
+  default     = "avg"
+}
+
+variable "pod_container_killed_by_oom_timeframe" {
+  description = "Monitor timeframe for Pod container killed by OOM [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`]"
+  type        = string
+  default     = "last_15m"
+}
+
+variable "pod_container_killed_by_oom_threshold_warning" {
+  description = "Pod container killed by OOM warning threshold"
+  type        = number
+  default     = 0
+}
+
+variable "pod_container_killed_by_oom_threshold_critical" {
+  description = "Pod container killed by OOM critical threshold"
+  type        = number
+  default     = 5
+}
+
+variable "pod_container_killed_by_oom_extra_tags" {
+  description = "Extra tags for Pod container killed by OOM monitor"
+  type        = list(string)
+  default     = []
+}
+
+# Pod frequently restarted
+variable "pod_frequently_restarted_enabled" {
+  description = "Flag to enable Pod frequently restarted monitor"
+  type        = string
+  default     = "true"
+}
+
+variable "pod_frequently_restarted_message" {
+  description = "Custom message for Pod frequently restarted monitor"
+  type        = string
+  default     = ""
+}
+
+variable "pod_frequently_restarted_time_aggregator" {
+  description = "Monitor aggregator for Pod frequently restarted [available values: min, max or avg]"
+  type        = string
+  default     = "min"
+}
+
+variable "pod_frequently_restarted_timeframe" {
+  description = "Monitor timeframe for Pod frequently restarted [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`]"
+  type        = string
+  default     = "last_15m"
+}
+
+variable "pod_frequently_restarted_threshold_warning" {
+  description = "Pod frequently restarted warning threshold"
+  type        = number
+  default     = 5
+}
+
+variable "pod_frequently_restarted_threshold_critical" {
+  description = "Pod frequently restarted critical threshold"
+  type        = number
+  default     = 10
+}
+
+variable "pod_frequently_restarted_extra_tags" {
+  description = "Extra tags for Pod frequently restarted monitor"
+  type        = list(string)
+  default     = []
+}
+
+# General filter tags
 variable "pod_group_by" {
   default     = ["kube_namespace", "pod_name", "reason", "kube_cluster_name"]
   description = "Select group by element on monitors (error and terminated)"

--- a/caas/kubernetes/pod/monitors-k8s-pod.tf
+++ b/caas/kubernetes/pod/monitors-k8s-pod.tf
@@ -119,7 +119,7 @@ EOQ
 
 resource "datadog_monitor" "pod_frequently_restarted" {
   count   = var.pod_frequently_restarted_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes pods in {{kube_replica_set}} frequently restarted on {{kube_cluster_name}}"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Pods in {{kube_replica_set}} frequently restarted on {{kube_cluster_name}}"
   message = coalesce(var.pod_frequently_restarted_message, var.message)
   type    = "metric alert"
 

--- a/caas/kubernetes/pod/monitors-k8s-pod.tf
+++ b/caas/kubernetes/pod/monitors-k8s-pod.tf
@@ -87,3 +87,63 @@ EOQ
   tags = concat(local.common_tags, var.tags, var.terminated_extra_tags)
 }
 
+resource "datadog_monitor" "pod_container_killed_by_oom" {
+  count   = var.pod_container_killed_by_oom_enabled == "true" ? 1 : 0
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Pod {{pod_name}} container {{kube_container_name}} killed by OOM on {{kube_cluster_name}}"
+  message = coalesce(var.pod_container_killed_by_oom_message, var.message)
+  type    = "query alert"
+
+  query = <<EOQ
+    ${var.pod_container_killed_by_oom_time_aggregator}(${var.pod_container_killed_by_oom_timeframe}):
+      avg:container.memory.oom_events${module.filter-tags.query_alert} by {pod_name,kube_container_name,kube_cluster_name}
+    > ${var.pod_container_killed_by_oom_threshold_critical}
+EOQ
+
+  monitor_thresholds {
+    warning  = var.pod_container_killed_by_oom_threshold_warning
+    critical = var.pod_container_killed_by_oom_threshold_critical
+  }
+
+  evaluation_delay    = var.evaluation_delay
+  new_host_delay      = var.new_host_delay
+  new_group_delay     = var.new_group_delay
+  notify_no_data      = false
+  renotify_interval   = 0
+  notify_audit        = false
+  timeout_h           = var.timeout_h
+  include_tags        = true
+  require_full_window = true
+
+  tags = concat(local.common_tags, var.tags, var.pod_container_killed_by_oom_extra_tags)
+}
+
+resource "datadog_monitor" "pod_frequently_restarted" {
+  count   = var.pod_frequently_restarted_enabled == "true" ? 1 : 0
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes pods in {{kube_replica_set}} frequently restarted on {{kube_cluster_name}}"
+  message = coalesce(var.pod_frequently_restarted_message, var.message)
+  type    = "metric alert"
+
+  query = <<EOQ
+    change(${var.pod_frequently_restarted_time_aggregator}(${var.pod_frequently_restarted_timeframe}), ${var.pod_frequently_restarted_timeframe}):
+      max:kubernetes_state.container.restarts${module.filter-tags.query_alert} by {kube_replica_set,kube_namespace,kube_cluster_name}
+    >= ${var.pod_frequently_restarted_threshold_critical}
+EOQ
+
+  monitor_thresholds {
+    warning  = var.pod_frequently_restarted_threshold_warning
+    critical = var.pod_frequently_restarted_threshold_critical
+  }
+
+  evaluation_delay = var.evaluation_delay
+  new_host_delay   = var.new_host_delay
+  new_group_delay  = var.new_group_delay
+
+  notify_no_data      = false
+  renotify_interval   = 0
+  notify_audit        = false
+  timeout_h           = var.timeout_h
+  include_tags        = true
+  require_full_window = true
+
+  tags = concat(local.common_tags, var.tags, var.pod_frequently_restarted_extra_tags)
+}

--- a/caas/kubernetes/pod/outputs.tf
+++ b/caas/kubernetes/pod/outputs.tf
@@ -3,6 +3,16 @@ output "error_id" {
   value       = datadog_monitor.error.*.id
 }
 
+output "pod_container_killed_by_oom_id" {
+  description = "id for monitor pod_container_killed_by_oom"
+  value       = datadog_monitor.pod_container_killed_by_oom.*.id
+}
+
+output "pod_frequently_restarted_id" {
+  description = "id for monitor pod_frequently_restarted"
+  value       = datadog_monitor.pod_frequently_restarted.*.id
+}
+
 output "pod_phase_status_id" {
   description = "id for monitor pod_phase_status"
   value       = datadog_monitor.pod_phase_status.*.id

--- a/caas/kubernetes/workload/README.md
+++ b/caas/kubernetes/workload/README.md
@@ -22,7 +22,7 @@ Creates DataDog monitors with the following checks:
 - Kubernetes Current replicas
 - Kubernetes DaemonSet {{kube_daemon_set}} not ready on {{kube_cluster_name}}
 - Kubernetes Deployment {{kube_deployment}} replica too low on {{kube_cluster_name}}
-- Kubernetes HPA Cannot Scale Out Further {{horizontalpodautoscaler}} on {{kube_cluster_name}}
+- Kubernetes HPA cannot scale out further {{horizontalpodautoscaler}} on {{kube_cluster_name}}
 - Kubernetes job failed
 - Kubernetes Pod Disruption Budget {{poddisruptionbudget}} not respected on {{kube_cluster_name}}
 - Kubernetes Ready replicas

--- a/caas/kubernetes/workload/README.md
+++ b/caas/kubernetes/workload/README.md
@@ -20,8 +20,13 @@ Creates DataDog monitors with the following checks:
 - Kubernetes Available replicas
 - Kubernetes cronjob scheduling failed
 - Kubernetes Current replicas
+- Kubernetes DaemonSet {{kube_daemon_set}} not ready on {{kube_cluster_name}}
+- Kubernetes Deployment {{kube_deployment}} replica too low on {{kube_cluster_name}}
+- Kubernetes HPA Cannot Scale Out Further {{horizontalpodautoscaler}} on {{kube_cluster_name}}
 - Kubernetes job failed
+- Kubernetes Pod Disruption Budget {{poddisruptionbudget}} not respected on {{kube_cluster_name}}
 - Kubernetes Ready replicas
+- Kubernetes StatefulSet {{kube_stateful_set}} not ready on {{kube_cluster_name}}
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -48,10 +53,15 @@ Creates DataDog monitors with the following checks:
 | Name | Type |
 |------|------|
 | [datadog_monitor.cronjob](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
+| [datadog_monitor.daemonset_pods_not_ready](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
+| [datadog_monitor.deployments_replica_too_low](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
+| [datadog_monitor.hpa_cannot_scaleup_further](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.job](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
+| [datadog_monitor.pod_disruption_budget_not_respected](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.replica_available](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.replica_current](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 | [datadog_monitor.replica_ready](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
+| [datadog_monitor.statefulset_pods_not_ready](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor) | resource |
 
 ## Inputs
 
@@ -62,13 +72,32 @@ Creates DataDog monitors with the following checks:
 | <a name="input_cronjob_message"></a> [cronjob\_message](#input\_cronjob\_message) | Custom message for Cronjob monitor | `string` | `""` | no |
 | <a name="input_cronjob_threshold_warning"></a> [cronjob\_threshold\_warning](#input\_cronjob\_threshold\_warning) | Cronjob monitor (warning threshold) | `string` | `3` | no |
 | <a name="input_cronjobfailed_group_by"></a> [cronjobfailed\_group\_by](#input\_cronjobfailed\_group\_by) | n/a | `list` | <pre>[<br>  "kube_cronjob"<br>]</pre> | no |
+| <a name="input_daemonset_pods_not_ready_enabled"></a> [daemonset\_pods\_not\_ready\_enabled](#input\_daemonset\_pods\_not\_ready\_enabled) | Flag to enable DaemonSet pods not ready monitor | `string` | `"true"` | no |
+| <a name="input_daemonset_pods_not_ready_extra_tags"></a> [daemonset\_pods\_not\_ready\_extra\_tags](#input\_daemonset\_pods\_not\_ready\_extra\_tags) | Extra tags for DaemonSet pods not ready monitor | `list(string)` | `[]` | no |
+| <a name="input_daemonset_pods_not_ready_message"></a> [daemonset\_pods\_not\_ready\_message](#input\_daemonset\_pods\_not\_ready\_message) | Custom message for DaemonSet pods not ready monitor | `string` | `""` | no |
+| <a name="input_daemonset_pods_not_ready_threshold_critical"></a> [daemonset\_pods\_not\_ready\_threshold\_critical](#input\_daemonset\_pods\_not\_ready\_threshold\_critical) | DaemonSet pods not ready critical threshold | `number` | `1` | no |
+| <a name="input_daemonset_pods_not_ready_time_aggregator"></a> [daemonset\_pods\_not\_ready\_time\_aggregator](#input\_daemonset\_pods\_not\_ready\_time\_aggregator) | Monitor aggregator for DaemonSet pods not ready [available values: min, max or avg] | `string` | `"max"` | no |
+| <a name="input_daemonset_pods_not_ready_timeframe"></a> [daemonset\_pods\_not\_ready\_timeframe](#input\_daemonset\_pods\_not\_ready\_timeframe) | Monitor timeframe for DaemonSet pods not ready [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_30m"` | no |
 | <a name="input_deployment_group_by"></a> [deployment\_group\_by](#input\_deployment\_group\_by) | Select group by element on deployment monitors | `list` | <pre>[<br>  "kube_namespace",<br>  "kube_deployment",<br>  "kube_cluster_name"<br>]</pre> | no |
+| <a name="input_deployments_replica_too_low_enabled"></a> [deployments\_replica\_too\_low\_enabled](#input\_deployments\_replica\_too\_low\_enabled) | Flag to enable Deployment replica too low monitor | `string` | `"true"` | no |
+| <a name="input_deployments_replica_too_low_extra_tags"></a> [deployments\_replica\_too\_low\_extra\_tags](#input\_deployments\_replica\_too\_low\_extra\_tags) | Extra tags for Deployment replica too low monitor | `list(string)` | `[]` | no |
+| <a name="input_deployments_replica_too_low_message"></a> [deployments\_replica\_too\_low\_message](#input\_deployments\_replica\_too\_low\_message) | Custom message for Deployment replica too low monitor | `string` | `""` | no |
+| <a name="input_deployments_replica_too_low_threshold_critical"></a> [deployments\_replica\_too\_low\_threshold\_critical](#input\_deployments\_replica\_too\_low\_threshold\_critical) | Deployment replica too low critical threshold | `number` | `0` | no |
+| <a name="input_deployments_replica_too_low_time_aggregator"></a> [deployments\_replica\_too\_low\_time\_aggregator](#input\_deployments\_replica\_too\_low\_time\_aggregator) | Monitor aggregator for Deployment replica too low [available values: min, max or avg] | `string` | `"max"` | no |
+| <a name="input_deployments_replica_too_low_timeframe"></a> [deployments\_replica\_too\_low\_timeframe](#input\_deployments\_replica\_too\_low\_timeframe) | Monitor timeframe for Deployment replica too low [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_15m"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Architecture Environment | `string` | n/a | yes |
 | <a name="input_evaluation_delay"></a> [evaluation\_delay](#input\_evaluation\_delay) | Delay in seconds for the metric evaluation | `number` | `15` | no |
 | <a name="input_filter_tags_custom"></a> [filter\_tags\_custom](#input\_filter\_tags\_custom) | Tags used for custom filtering when filter\_tags\_use\_defaults is false | `string` | `"*"` | no |
 | <a name="input_filter_tags_custom_excluded"></a> [filter\_tags\_custom\_excluded](#input\_filter\_tags\_custom\_excluded) | Tags excluded for custom filtering when filter\_tags\_use\_defaults is false | `string` | `""` | no |
 | <a name="input_filter_tags_separator"></a> [filter\_tags\_separator](#input\_filter\_tags\_separator) | Set the filter tags separator (, or AND) | `string` | `","` | no |
 | <a name="input_filter_tags_use_defaults"></a> [filter\_tags\_use\_defaults](#input\_filter\_tags\_use\_defaults) | Use default filter tags convention | `string` | `"true"` | no |
+| <a name="input_hpa_cannot_scaleup_further_enabled"></a> [hpa\_cannot\_scaleup\_further\_enabled](#input\_hpa\_cannot\_scaleup\_further\_enabled) | Flag to enable HPA cannot scale up further monitor | `string` | `"true"` | no |
+| <a name="input_hpa_cannot_scaleup_further_extra_tags"></a> [hpa\_cannot\_scaleup\_further\_extra\_tags](#input\_hpa\_cannot\_scaleup\_further\_extra\_tags) | Extra tags for HPA cannot scale up further monitor | `list(string)` | `[]` | no |
+| <a name="input_hpa_cannot_scaleup_further_message"></a> [hpa\_cannot\_scaleup\_further\_message](#input\_hpa\_cannot\_scaleup\_further\_message) | Custom message for HPA cannot scale up further monitor | `string` | `""` | no |
+| <a name="input_hpa_cannot_scaleup_further_threshold_critical"></a> [hpa\_cannot\_scaleup\_further\_threshold\_critical](#input\_hpa\_cannot\_scaleup\_further\_threshold\_critical) | HPA cannot scale up further critical threshold | `number` | `100` | no |
+| <a name="input_hpa_cannot_scaleup_further_threshold_warning"></a> [hpa\_cannot\_scaleup\_further\_threshold\_warning](#input\_hpa\_cannot\_scaleup\_further\_threshold\_warning) | HPA cannot scale up further warning threshold | `number` | `90` | no |
+| <a name="input_hpa_cannot_scaleup_further_time_aggregator"></a> [hpa\_cannot\_scaleup\_further\_time\_aggregator](#input\_hpa\_cannot\_scaleup\_further\_time\_aggregator) | Monitor aggregator for HPA cannot scale up further [available values: min, max or avg] | `string` | `"avg"` | no |
+| <a name="input_hpa_cannot_scaleup_further_timeframe"></a> [hpa\_cannot\_scaleup\_further\_timeframe](#input\_hpa\_cannot\_scaleup\_further\_timeframe) | Monitor timeframe for HPA cannot scale up further [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_30m"` | no |
 | <a name="input_job_enabled"></a> [job\_enabled](#input\_job\_enabled) | Flag to enable Job monitor | `string` | `"true"` | no |
 | <a name="input_job_extra_tags"></a> [job\_extra\_tags](#input\_job\_extra\_tags) | Extra tags for Job monitor | `list(string)` | `[]` | no |
 | <a name="input_job_message"></a> [job\_message](#input\_job\_message) | Custom message for Job monitor | `string` | `""` | no |
@@ -78,6 +107,12 @@ Creates DataDog monitors with the following checks:
 | <a name="input_new_group_delay"></a> [new\_group\_delay](#input\_new\_group\_delay) | Delay in seconds before monitor new resource | `number` | `300` | no |
 | <a name="input_new_host_delay"></a> [new\_host\_delay](#input\_new\_host\_delay) | Delay in seconds before monitor new resource | `number` | `300` | no |
 | <a name="input_notify_no_data"></a> [notify\_no\_data](#input\_notify\_no\_data) | Will raise no data alert if set to true | `bool` | `true` | no |
+| <a name="input_pod_disruption_budget_not_respected_enabled"></a> [pod\_disruption\_budget\_not\_respected\_enabled](#input\_pod\_disruption\_budget\_not\_respected\_enabled) | Flag to enable Pod Disruption Budget not respected monitor | `string` | `"true"` | no |
+| <a name="input_pod_disruption_budget_not_respected_extra_tags"></a> [pod\_disruption\_budget\_not\_respected\_extra\_tags](#input\_pod\_disruption\_budget\_not\_respected\_extra\_tags) | Extra tags for Pod Disruption Budget not respected monitor | `list(string)` | `[]` | no |
+| <a name="input_pod_disruption_budget_not_respected_message"></a> [pod\_disruption\_budget\_not\_respected\_message](#input\_pod\_disruption\_budget\_not\_respected\_message) | Custom message for Pod Disruption Budget not respected monitor | `string` | `""` | no |
+| <a name="input_pod_disruption_budget_not_respected_threshold_critical"></a> [pod\_disruption\_budget\_not\_respected\_threshold\_critical](#input\_pod\_disruption\_budget\_not\_respected\_threshold\_critical) | Pod Disruption Budget not respected critical threshold | `number` | `0` | no |
+| <a name="input_pod_disruption_budget_not_respected_time_aggregator"></a> [pod\_disruption\_budget\_not\_respected\_time\_aggregator](#input\_pod\_disruption\_budget\_not\_respected\_time\_aggregator) | Monitor aggregator for Pod Disruption Budget not respected [available values: min, max or avg] | `string` | `"max"` | no |
+| <a name="input_pod_disruption_budget_not_respected_timeframe"></a> [pod\_disruption\_budget\_not\_respected\_timeframe](#input\_pod\_disruption\_budget\_not\_respected\_timeframe) | Monitor timeframe for Pod Disruption Budget not respected [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_15m"` | no |
 | <a name="input_prefix_slug"></a> [prefix\_slug](#input\_prefix\_slug) | Prefix string to prepend between brackets on every monitors names | `string` | `""` | no |
 | <a name="input_replica_available_enabled"></a> [replica\_available\_enabled](#input\_replica\_available\_enabled) | Flag to enable Available replica monitor | `string` | `"true"` | no |
 | <a name="input_replica_available_extra_tags"></a> [replica\_available\_extra\_tags](#input\_replica\_available\_extra\_tags) | Extra tags for Available replicamonitor | `list(string)` | `[]` | no |
@@ -98,6 +133,12 @@ Creates DataDog monitors with the following checks:
 | <a name="input_replica_ready_threshold_critical"></a> [replica\_ready\_threshold\_critical](#input\_replica\_ready\_threshold\_critical) | Ready replica critical threshold | `number` | `1` | no |
 | <a name="input_replica_ready_time_aggregator"></a> [replica\_ready\_time\_aggregator](#input\_replica\_ready\_time\_aggregator) | Monitor aggregator for Ready replica [available values: min, max or avg] | `string` | `"max"` | no |
 | <a name="input_replica_ready_timeframe"></a> [replica\_ready\_timeframe](#input\_replica\_ready\_timeframe) | Monitor timeframe for Ready replica [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_5m"` | no |
+| <a name="input_statefulset_pods_not_ready_enabled"></a> [statefulset\_pods\_not\_ready\_enabled](#input\_statefulset\_pods\_not\_ready\_enabled) | Flag to enable StatefulSet pods not ready monitor | `string` | `"true"` | no |
+| <a name="input_statefulset_pods_not_ready_extra_tags"></a> [statefulset\_pods\_not\_ready\_extra\_tags](#input\_statefulset\_pods\_not\_ready\_extra\_tags) | Extra tags for StatefulSet pods not ready monitor | `list(string)` | `[]` | no |
+| <a name="input_statefulset_pods_not_ready_message"></a> [statefulset\_pods\_not\_ready\_message](#input\_statefulset\_pods\_not\_ready\_message) | Custom message for StatefulSet pods not ready monitor | `string` | `""` | no |
+| <a name="input_statefulset_pods_not_ready_threshold_critical"></a> [statefulset\_pods\_not\_ready\_threshold\_critical](#input\_statefulset\_pods\_not\_ready\_threshold\_critical) | StatefulSet pods not ready critical threshold | `number` | `100` | no |
+| <a name="input_statefulset_pods_not_ready_time_aggregator"></a> [statefulset\_pods\_not\_ready\_time\_aggregator](#input\_statefulset\_pods\_not\_ready\_time\_aggregator) | Monitor aggregator for StatefulSet pods not ready [available values: min, max or avg] | `string` | `"max"` | no |
+| <a name="input_statefulset_pods_not_ready_timeframe"></a> [statefulset\_pods\_not\_ready\_timeframe](#input\_statefulset\_pods\_not\_ready\_timeframe) | Monitor timeframe for StatefulSet pods not ready [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_15m"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Global variables | `list(string)` | <pre>[<br>  "type:caas",<br>  "provider:kubernetes",<br>  "resource:kubernetes-workload"<br>]</pre> | no |
 | <a name="input_team"></a> [team](#input\_team) | n/a | `string` | `"claranet"` | no |
 | <a name="input_timeout_h"></a> [timeout\_h](#input\_timeout\_h) | Default auto-resolving state (in hours) | `number` | `0` | no |
@@ -107,10 +148,15 @@ Creates DataDog monitors with the following checks:
 | Name | Description |
 |------|-------------|
 | <a name="output_cronjob_id"></a> [cronjob\_id](#output\_cronjob\_id) | id for monitor cronjob |
+| <a name="output_daemonset_pods_not_ready_id"></a> [daemonset\_pods\_not\_ready\_id](#output\_daemonset\_pods\_not\_ready\_id) | id for monitor daemonset\_pods\_not\_ready |
+| <a name="output_deployments_replica_too_low_id"></a> [deployments\_replica\_too\_low\_id](#output\_deployments\_replica\_too\_low\_id) | id for monitor deployments\_replica\_too\_low |
+| <a name="output_hpa_cannot_scaleup_further_id"></a> [hpa\_cannot\_scaleup\_further\_id](#output\_hpa\_cannot\_scaleup\_further\_id) | id for monitor hpa\_cannot\_scaleup\_further |
 | <a name="output_job_id"></a> [job\_id](#output\_job\_id) | id for monitor job |
+| <a name="output_pod_disruption_budget_not_respected_id"></a> [pod\_disruption\_budget\_not\_respected\_id](#output\_pod\_disruption\_budget\_not\_respected\_id) | id for monitor pod\_disruption\_budget\_not\_respected |
 | <a name="output_replica_available_id"></a> [replica\_available\_id](#output\_replica\_available\_id) | id for monitor replica\_available |
 | <a name="output_replica_current_id"></a> [replica\_current\_id](#output\_replica\_current\_id) | id for monitor replica\_current |
 | <a name="output_replica_ready_id"></a> [replica\_ready\_id](#output\_replica\_ready\_id) | id for monitor replica\_ready |
+| <a name="output_statefulset_pods_not_ready_id"></a> [statefulset\_pods\_not\_ready\_id](#output\_statefulset\_pods\_not\_ready\_id) | id for monitor statefulset\_pods\_not\_ready |
 <!-- END_TF_DOCS -->
 ## Related documentation
 

--- a/caas/kubernetes/workload/inputs.tf
+++ b/caas/kubernetes/workload/inputs.tf
@@ -214,6 +214,198 @@ variable "replica_current_threshold_critical" {
   description = "Current replica critical threshold"
 }
 
+# DaemonSet not ready
+variable "daemonset_pods_not_ready_enabled" {
+  description = "Flag to enable DaemonSet pods not ready monitor"
+  type        = string
+  default     = "true"
+}
+
+variable "daemonset_pods_not_ready_message" {
+  description = "Custom message for DaemonSet pods not ready monitor"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_pods_not_ready_time_aggregator" {
+  description = "Monitor aggregator for DaemonSet pods not ready [available values: min, max or avg]"
+  type        = string
+  default     = "max"
+}
+
+variable "daemonset_pods_not_ready_timeframe" {
+  description = "Monitor timeframe for DaemonSet pods not ready [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`]"
+  type        = string
+  default     = "last_30m"
+}
+
+variable "daemonset_pods_not_ready_threshold_critical" {
+  description = "DaemonSet pods not ready critical threshold"
+  type        = number
+  default     = 1
+}
+
+variable "daemonset_pods_not_ready_extra_tags" {
+  description = "Extra tags for DaemonSet pods not ready monitor"
+  type        = list(string)
+  default     = []
+}
+
+# StatefulSet not ready
+variable "statefulset_pods_not_ready_enabled" {
+  description = "Flag to enable StatefulSet pods not ready monitor"
+  type        = string
+  default     = "true"
+}
+
+variable "statefulset_pods_not_ready_message" {
+  description = "Custom message for StatefulSet pods not ready monitor"
+  type        = string
+  default     = ""
+}
+
+variable "statefulset_pods_not_ready_time_aggregator" {
+  description = "Monitor aggregator for StatefulSet pods not ready [available values: min, max or avg]"
+  type        = string
+  default     = "max"
+}
+
+variable "statefulset_pods_not_ready_timeframe" {
+  description = "Monitor timeframe for StatefulSet pods not ready [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`]"
+  type        = string
+  default     = "last_15m"
+}
+
+variable "statefulset_pods_not_ready_threshold_critical" {
+  description = "StatefulSet pods not ready critical threshold"
+  type        = number
+  default     = 100
+}
+
+variable "statefulset_pods_not_ready_extra_tags" {
+  description = "Extra tags for StatefulSet pods not ready monitor"
+  type        = list(string)
+  default     = []
+}
+
+# Deployments replica too low
+variable "deployments_replica_too_low_enabled" {
+  description = "Flag to enable Deployment replica too low monitor"
+  type        = string
+  default     = "true"
+}
+
+variable "deployments_replica_too_low_message" {
+  description = "Custom message for Deployment replica too low monitor"
+  type        = string
+  default     = ""
+}
+
+variable "deployments_replica_too_low_time_aggregator" {
+  description = "Monitor aggregator for Deployment replica too low [available values: min, max or avg]"
+  type        = string
+  default     = "max"
+}
+
+variable "deployments_replica_too_low_timeframe" {
+  description = "Monitor timeframe for Deployment replica too low [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`]"
+  type        = string
+  default     = "last_15m"
+}
+
+variable "deployments_replica_too_low_threshold_critical" {
+  description = "Deployment replica too low critical threshold"
+  type        = number
+  default     = 0
+}
+
+variable "deployments_replica_too_low_extra_tags" {
+  description = "Extra tags for Deployment replica too low monitor"
+  type        = list(string)
+  default     = []
+}
+
+# HPA cannot scale up further
+variable "hpa_cannot_scaleup_further_enabled" {
+  description = "Flag to enable HPA cannot scale up further monitor"
+  type        = string
+  default     = "true"
+}
+
+variable "hpa_cannot_scaleup_further_message" {
+  description = "Custom message for HPA cannot scale up further monitor"
+  type        = string
+  default     = ""
+}
+
+variable "hpa_cannot_scaleup_further_time_aggregator" {
+  description = "Monitor aggregator for HPA cannot scale up further [available values: min, max or avg]"
+  type        = string
+  default     = "avg"
+}
+
+variable "hpa_cannot_scaleup_further_timeframe" {
+  description = "Monitor timeframe for HPA cannot scale up further [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`]"
+  type        = string
+  default     = "last_30m"
+}
+
+variable "hpa_cannot_scaleup_further_threshold_critical" {
+  description = "HPA cannot scale up further critical threshold"
+  type        = number
+  default     = 100
+}
+
+variable "hpa_cannot_scaleup_further_threshold_warning" {
+  description = "HPA cannot scale up further warning threshold"
+  type        = number
+  default     = 90
+}
+
+variable "hpa_cannot_scaleup_further_extra_tags" {
+  description = "Extra tags for HPA cannot scale up further monitor"
+  type        = list(string)
+  default     = []
+}
+
+# Pod Disruption Budget not respected
+variable "pod_disruption_budget_not_respected_enabled" {
+  description = "Flag to enable Pod Disruption Budget not respected monitor"
+  type        = string
+  default     = "true"
+}
+
+variable "pod_disruption_budget_not_respected_message" {
+  description = "Custom message for Pod Disruption Budget not respected monitor"
+  type        = string
+  default     = ""
+}
+
+variable "pod_disruption_budget_not_respected_time_aggregator" {
+  description = "Monitor aggregator for Pod Disruption Budget not respected [available values: min, max or avg]"
+  type        = string
+  default     = "max"
+}
+
+variable "pod_disruption_budget_not_respected_timeframe" {
+  description = "Monitor timeframe for Pod Disruption Budget not respected [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`]"
+  type        = string
+  default     = "last_15m"
+}
+
+variable "pod_disruption_budget_not_respected_threshold_critical" {
+  description = "Pod Disruption Budget not respected critical threshold"
+  type        = number
+  default     = 0
+}
+
+variable "pod_disruption_budget_not_respected_extra_tags" {
+  description = "Extra tags for Pod Disruption Budget not respected monitor"
+  type        = list(string)
+  default     = []
+}
+
+# General filter tags
 variable "replica_group_by" {
   default     = ["kube_namespace", "kube_replica_set", "kube_cluster_name"]
   description = "Select group by element on replicaset monitors"

--- a/caas/kubernetes/workload/monitors-k8s-workload.tf
+++ b/caas/kubernetes/workload/monitors-k8s-workload.tf
@@ -142,3 +142,155 @@ EOQ
   tags = concat(local.common_tags, var.tags, var.replica_current_extra_tags)
 }
 
+resource "datadog_monitor" "deployments_replica_too_low" {
+  count   = var.deployments_replica_too_low_enabled == "true" ? 1 : 0
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Deployment {{kube_deployment}} replica too low on {{kube_cluster_name}}"
+  message = coalesce(var.deployments_replica_too_low_message, var.message)
+  type    = "query alert"
+
+  query = <<EOQ
+    ${var.deployments_replica_too_low_time_aggregator}(${var.deployments_replica_too_low_timeframe}):
+      avg:kubernetes_state.deployment.replicas_available${module.filter-tags.query_alert} by {kube_deployment,kube_namespace,kube_cluster_name}
+    - avg:kubernetes_state.deployment.replicas_desired${module.filter-tags.query_alert} by {kube_deployment,kube_namespace,kube_cluster_name}
+    < ${var.deployments_replica_too_low_threshold_critical}
+EOQ
+
+  monitor_thresholds {
+    critical = var.deployments_replica_too_low_threshold_critical
+  }
+
+  evaluation_delay = var.evaluation_delay
+  new_group_delay  = var.new_group_delay
+
+  notify_no_data      = false
+  renotify_interval   = 0
+  notify_audit        = false
+  timeout_h           = var.timeout_h
+  include_tags        = false
+  require_full_window = true
+
+  tags = concat(local.common_tags, var.tags, var.deployments_replica_too_low_extra_tags)
+}
+
+resource "datadog_monitor" "daemonset_pods_not_ready" {
+  count   = var.daemonset_pods_not_ready_enabled == "true" ? 1 : 0
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes DaemonSet {{kube_daemon_set}} not ready on {{kube_cluster_name}}"
+  message = coalesce(var.daemonset_pods_not_ready_message, var.message)
+  type    = "query alert"
+
+  query = <<EOQ
+    ${var.daemonset_pods_not_ready_time_aggregator}(${var.daemonset_pods_not_ready_timeframe}):
+      sum:kubernetes_state.daemonset.ready${module.filter-tags.query_alert} by {kube_daemon_set,kube_cluster_name}
+      / sum:kubernetes_state.daemonset.desired${module.filter-tags.query_alert} by {kube_daemon_set,kube_cluster_name}
+    > ${var.daemonset_pods_not_ready_threshold_critical}
+EOQ
+
+  monitor_thresholds {
+    critical = var.daemonset_pods_not_ready_threshold_critical
+  }
+
+  evaluation_delay    = var.evaluation_delay
+  new_host_delay      = var.new_host_delay
+  new_group_delay     = var.new_group_delay
+  notify_no_data      = false
+  renotify_interval   = 0
+  notify_audit        = false
+  timeout_h           = var.timeout_h
+  include_tags        = true
+  require_full_window = true
+
+  tags = concat(local.common_tags, var.tags, var.daemonset_pods_not_ready_extra_tags)
+}
+
+resource "datadog_monitor" "statefulset_pods_not_ready" {
+  count   = var.statefulset_pods_not_ready_enabled == "true" ? 1 : 0
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes StatefulSet {{kube_stateful_set}} not ready on {{kube_cluster_name}}"
+  message = coalesce(var.statefulset_pods_not_ready_message, var.message)
+  type    = "query alert"
+
+  query = <<EOQ
+    ${var.statefulset_pods_not_ready_time_aggregator}(${var.statefulset_pods_not_ready_timeframe}):
+      avg:kubernetes_state.statefulset.ready${module.filter-tags.query_alert} by {kube_stateful_set,kube_namespace,kube_cluster_name}
+      / avg:kubernetes_state.statefulset.desired${module.filter-tags.query_alert} by {kube_stateful_set,kube_namespace,kube_cluster_name}
+      * 100
+    < ${var.statefulset_pods_not_ready_threshold_critical}
+EOQ
+
+  monitor_thresholds {
+    critical = var.statefulset_pods_not_ready_threshold_critical
+  }
+
+  evaluation_delay    = var.evaluation_delay
+  new_host_delay      = var.new_host_delay
+  new_group_delay     = var.new_group_delay
+  notify_no_data      = false
+  renotify_interval   = 0
+  notify_audit        = false
+  timeout_h           = var.timeout_h
+  include_tags        = true
+  require_full_window = true
+
+  tags = concat(local.common_tags, var.tags, var.statefulset_pods_not_ready_extra_tags)
+}
+
+resource "datadog_monitor" "hpa_cannot_scaleup_further" {
+  count   = var.hpa_cannot_scaleup_further_enabled == "true" ? 1 : 0
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes HPA Cannot Scale Out Further {{horizontalpodautoscaler}} on {{kube_cluster_name}}"
+  message = coalesce(var.hpa_cannot_scaleup_further_message, var.message)
+  type    = "query alert"
+
+  query = <<EOQ
+    ${var.hpa_cannot_scaleup_further_time_aggregator}(${var.hpa_cannot_scaleup_further_timeframe}):
+      avg:kubernetes_state.hpa.current_replicas${module.filter-tags.query_alert} by {horizontalpodautoscaler,kube_namespace,kube_cluster_name} 
+      * 100 
+      / avg:kubernetes_state.hpa.max_replicas${module.filter-tags.query_alert} by {horizontalpodautoscaler,kube_namespace,kube_cluster_name}
+    >= ${var.hpa_cannot_scaleup_further_threshold_critical}
+EOQ
+
+  monitor_thresholds {
+    critical = var.hpa_cannot_scaleup_further_threshold_critical
+    warning  = var.hpa_cannot_scaleup_further_threshold_warning
+  }
+
+  evaluation_delay    = var.evaluation_delay
+  new_host_delay      = var.new_host_delay
+  new_group_delay     = var.new_group_delay
+  notify_no_data      = false
+  renotify_interval   = 0
+  notify_audit        = false
+  timeout_h           = var.timeout_h
+  include_tags        = true
+  require_full_window = true
+
+  tags = concat(local.common_tags, var.tags, var.hpa_cannot_scaleup_further_extra_tags)
+}
+
+resource "datadog_monitor" "pod_disruption_budget_not_respected" {
+  count   = var.pod_disruption_budget_not_respected_enabled == "true" ? 1 : 0
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes Pod Disruption Budget {{poddisruptionbudget}} not respected on {{kube_cluster_name}}"
+  message = coalesce(var.pod_disruption_budget_not_respected_message, var.message)
+  type    = "query alert"
+
+  query = <<EOQ
+    ${var.pod_disruption_budget_not_respected_time_aggregator}(${var.pod_disruption_budget_not_respected_timeframe}):
+      avg:kubernetes_state.pdb.pods_healthy${module.filter-tags.query_alert} by {poddisruptionbudget,kube_namespace,kube_cluster_name}
+      - avg:kubernetes_state.pdb.pods_desired${module.filter-tags.query_alert} by {poddisruptionbudget,kube_namespace,kube_cluster_name}
+    < ${var.pod_disruption_budget_not_respected_threshold_critical}
+EOQ
+
+  monitor_thresholds {
+    critical = var.pod_disruption_budget_not_respected_threshold_critical
+  }
+
+  evaluation_delay = var.evaluation_delay
+  new_group_delay  = var.new_group_delay
+
+  notify_no_data      = false
+  renotify_interval   = 0
+  notify_audit        = false
+  timeout_h           = var.timeout_h
+  include_tags        = false
+  require_full_window = true
+
+  tags = concat(local.common_tags, var.tags, var.pod_disruption_budget_not_respected_extra_tags)
+}

--- a/caas/kubernetes/workload/monitors-k8s-workload.tf
+++ b/caas/kubernetes/workload/monitors-k8s-workload.tf
@@ -210,8 +210,8 @@ resource "datadog_monitor" "statefulset_pods_not_ready" {
 
   query = <<EOQ
     ${var.statefulset_pods_not_ready_time_aggregator}(${var.statefulset_pods_not_ready_timeframe}):
-      avg:kubernetes_state.statefulset.ready${module.filter-tags.query_alert} by {kube_stateful_set,kube_namespace,kube_cluster_name}
-      / avg:kubernetes_state.statefulset.desired${module.filter-tags.query_alert} by {kube_stateful_set,kube_namespace,kube_cluster_name}
+      avg:kubernetes_state.statefulset.replicas_ready${module.filter-tags.query_alert} by {kube_stateful_set,kube_namespace,kube_cluster_name}
+      / avg:kubernetes_state.statefulset.replicas_desired${module.filter-tags.query_alert} by {kube_stateful_set,kube_namespace,kube_cluster_name}
       * 100
     < ${var.statefulset_pods_not_ready_threshold_critical}
 EOQ

--- a/caas/kubernetes/workload/monitors-k8s-workload.tf
+++ b/caas/kubernetes/workload/monitors-k8s-workload.tf
@@ -235,7 +235,7 @@ EOQ
 
 resource "datadog_monitor" "hpa_cannot_scaleup_further" {
   count   = var.hpa_cannot_scaleup_further_enabled == "true" ? 1 : 0
-  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes HPA Cannot Scale Out Further {{horizontalpodautoscaler}} on {{kube_cluster_name}}"
+  name    = "${var.prefix_slug == "" ? "" : "[${var.prefix_slug}]"}[${var.environment}] Kubernetes HPA cannot scale out further {{horizontalpodautoscaler}} on {{kube_cluster_name}}"
   message = coalesce(var.hpa_cannot_scaleup_further_message, var.message)
   type    = "query alert"
 

--- a/caas/kubernetes/workload/outputs.tf
+++ b/caas/kubernetes/workload/outputs.tf
@@ -3,9 +3,29 @@ output "cronjob_id" {
   value       = datadog_monitor.cronjob.*.id
 }
 
+output "daemonset_pods_not_ready_id" {
+  description = "id for monitor daemonset_pods_not_ready"
+  value       = datadog_monitor.daemonset_pods_not_ready.*.id
+}
+
+output "deployments_replica_too_low_id" {
+  description = "id for monitor deployments_replica_too_low"
+  value       = datadog_monitor.deployments_replica_too_low.*.id
+}
+
+output "hpa_cannot_scaleup_further_id" {
+  description = "id for monitor hpa_cannot_scaleup_further"
+  value       = datadog_monitor.hpa_cannot_scaleup_further.*.id
+}
+
 output "job_id" {
   description = "id for monitor job"
   value       = datadog_monitor.job.*.id
+}
+
+output "pod_disruption_budget_not_respected_id" {
+  description = "id for monitor pod_disruption_budget_not_respected"
+  value       = datadog_monitor.pod_disruption_budget_not_respected.*.id
 }
 
 output "replica_available_id" {
@@ -21,5 +41,10 @@ output "replica_current_id" {
 output "replica_ready_id" {
   description = "id for monitor replica_ready"
   value       = datadog_monitor.replica_ready.*.id
+}
+
+output "statefulset_pods_not_ready_id" {
+  description = "id for monitor statefulset_pods_not_ready"
+  value       = datadog_monitor.statefulset_pods_not_ready.*.id
 }
 


### PR DESCRIPTION
* Add Kubernetes monitors:
  * Kubernetes cluster heartbeat alert (replace deprecated apiserver monitor)
  * Kubernetes Pod container killed by OOM
  * Kubernetes pods frequently restarted
  * Kubernetes DaemonSet not ready
  * Kubernetes Deployment replica too low
  * Kubernetes HPA cannot scale out further
  * Kubernetes Pod Disruption Budget not respected
  * Kubernetes StatefulSet not ready
  * Kubernetes Nginx Ingress controller is down
* Update Kubernetes monitors:
  * Kubernetes API server does not respond is now disabled by default, replaced by heartbeat monitor, as this one doesn't work on AKS/GKE clusters for example (see https://docs.datadoghq.com/containers/kubernetes/control_plane/?tab=datadogoperator#ManagedServices)
  * Add tag in monitors title to easily identify problematic resources
* Remove Kubernetes monitors:
  * Node Out of disk monitor as metric doesn't exist anymore, use DiskPressure instead (see https://github.com/kubernetes/kubernetes/pull/70111)