### PR TITLE
Update Redis Monitors to be able to monitor Azure Cache for Redis and Azure Managed Redis

### DIFF
--- a/cloud/azure/redis/README.md
+++ b/cloud/azure/redis/README.md
@@ -8,6 +8,7 @@ module "datadog-monitors-cloud-azure-redis" {
   version     = "{revision}"
 
   environment = var.environment
+  server_type = "cache" # cache (Azure Cache for Redis) | managed (Azure Managed Redis)
   message     = module.datadog-message-alerting.alerting-message
 }
 
@@ -21,6 +22,7 @@ Creates DataDog monitors with the following checks:
 - Redis processor time too high
 - Redis server load too high
 - Redis too many evictedkeys
+- Supports both Azure Cache for Redis and Azure Managed Redis (`server_type`)
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -79,6 +81,7 @@ Creates DataDog monitors with the following checks:
 | <a name="input_percent_processor_time_timeframe"></a> [percent\_processor\_time\_timeframe](#input\_percent\_processor\_time\_timeframe) | Monitor timeframe for Redis processor [available values: `last_#m` (1, 5, 10, 15, or 30), `last_#h` (1, 2, or 4), or `last_1d`] | `string` | `"last_5m"` | no |
 | <a name="input_prefix_slug"></a> [prefix\_slug](#input\_prefix\_slug) | Prefix string to prepend between brackets on every monitors names | `string` | `""` | no |
 | <a name="input_priority"></a> [priority](#input\_priority) | Alert severity of monitors from 1 (high) to 5 (low) | `number` | `null` | no |
+| <a name="input_server_type"></a> [server\_type](#input\_server\_type) | Redis Server Type on Azure [available values: cache, managed] | `string` | `"cache"` | no |
 | <a name="input_server_load_rate_enabled"></a> [server\_load\_rate\_enabled](#input\_server\_load\_rate\_enabled) | Flag to enable Redis server load monitor | `string` | `"true"` | no |
 | <a name="input_server_load_rate_extra_tags"></a> [server\_load\_rate\_extra\_tags](#input\_server\_load\_rate\_extra\_tags) | Extra tags for Redis server load monitor | `list(string)` | `[]` | no |
 | <a name="input_server_load_rate_message"></a> [server\_load\_rate\_message](#input\_server\_load\_rate\_message) | Custom message for Redis server load monitor | `string` | `""` | no |

--- a/cloud/azure/redis/inputs.tf
+++ b/cloud/azure/redis/inputs.tf
@@ -58,6 +58,16 @@ variable "filter_tags_custom_excluded" {
 
 # Azure Redis specific variables
 
+variable "server_type" {
+  description = "Redis Server Type on Azure [available values: cache, managed]"
+  type        = string
+  default     = "cache"
+  validation {
+    condition     = contains(["cache", "managed"], var.server_type)
+    error_message = "Redis Server Type should be `cache` or `managed`."
+  }
+}
+
 variable "status_enabled" {
   description = "Flag to enable Redis status monitor"
   type        = string
@@ -207,4 +217,3 @@ variable "server_load_rate_threshold_warning" {
   description = "Server CPU load rate (warning threshold)"
   default     = 70
 }
-

--- a/cloud/azure/redis/locals.tf
+++ b/cloud/azure/redis/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  metric_namespace = { "cache" : "cache_redis", "managed" : "cache_redisenterprise" }[var.server_type]
+}

--- a/cloud/azure/redis/monitors-azure-redis.tf
+++ b/cloud/azure/redis/monitors-azure-redis.tf
@@ -6,7 +6,7 @@ resource "datadog_monitor" "status" {
 
   query = <<EOQ
     ${var.status_time_aggregator}(${var.status_timeframe}): (
-      avg:azure.cache_redis.count${module.filter-tags.query_alert} by {resource_group,region,name}
+      avg:azure.${local.metric_namespace}.count${module.filter-tags.query_alert} by {resource_group,region,name}
     ) != 1
 EOQ
 
@@ -32,7 +32,7 @@ resource "datadog_monitor" "evictedkeys" {
 
   query = <<EOQ
     ${var.evictedkeys_limit_time_aggregator}(${var.evictedkeys_limit_timeframe}): (
-      avg:azure.cache_redis.evictedkeys${module.filter-tags.query_alert} by {resource_group,region,name}
+      avg:azure.${local.metric_namespace}.evictedkeys${module.filter-tags.query_alert} by {resource_group,region,name}
      ) > ${var.evictedkeys_limit_threshold_critical}
 EOQ
 
@@ -62,7 +62,7 @@ resource "datadog_monitor" "percent_processor_time" {
 
   query = <<EOQ
     ${var.percent_processor_time_time_aggregator}(${var.percent_processor_time_timeframe}): (
-      avg:azure.cache_redis.percent_processor_time${module.filter-tags.query_alert} by {resource_group,region,name}
+      avg:azure.${local.metric_namespace}.percent_processor_time${module.filter-tags.query_alert} by {resource_group,region,name}
     ) > ${var.percent_processor_time_threshold_critical}
 EOQ
 
@@ -92,7 +92,7 @@ resource "datadog_monitor" "server_load" {
 
   query = <<EOQ
     ${var.server_load_rate_time_aggregator}(${var.server_load_rate_timeframe}): (
-      avg:azure.cache_redis.server_load${module.filter-tags.query_alert} by {resource_group,region,name}
+      avg:azure.${local.metric_namespace}.server_load${module.filter-tags.query_alert} by {resource_group,region,name}
     ) > ${var.server_load_rate_threshold_critical}
 EOQ
 


### PR DESCRIPTION
## Summary
This MR updates the Azure Redis monitor module to support both Redis offerings by introducing a `server_type` input and dynamic metric namespace selection.

## Changes
- Added `server_type` variable with validation:
  - `cache` (Azure Cache for Redis)
  - `managed` (Azure Managed Redis)
- Added `local.metric_namespace` mapping:
  - `cache -> cache_redis`
  - `managed` -> `cache_redisenterprise`
- Updated all monitor queries to use `azure.${local.metric_namespace}.*`
- Updated README usage and inputs documentation accordingly.

## Impact
- Backward compatible by default (`server_type = "cache"`).
- Enables targeting Azure Managed Redis metrics without duplicating the module.
